### PR TITLE
dev: trigger `wp_login` action on successful login

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to a modified version of [Semantic Versioning](./README.md#updating-and-versioning).
 
 ## Unreleased
-- chore: update Composer dependencies.
-- chore: update NPM dependencies.
+- dev: Trigger `wp_login` action on successful login.
+- chore: Update Composer dependencies.
+- chore: Update NPM dependencies.
 - ci: Update workflow actions to latest versions.
 - ci: Fix XDebug install in Docker for PHP 7.x.
 

--- a/src/Auth/Auth.php
+++ b/src/Auth/Auth.php
@@ -81,6 +81,9 @@ class Auth {
 		// Login and generate the tokens.
 		wp_set_current_user( $user->ID );
 
+		// Trigger the login action.
+		do_action( 'wp_login', $user->user_login, $user ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound
+
 		$payload = [
 			'authToken'              => TokenManager::get_auth_token( $user ),
 			'authTokenExpiration'    => User::get_auth_token_expiration( $user->ID ),

--- a/src/Mutation/LoginWithPassword.php
+++ b/src/Mutation/LoginWithPassword.php
@@ -77,6 +77,9 @@ class LoginWithPassword extends MutationType {
 
 			wp_set_current_user( $user->ID );
 
+			// Trigger the login action.
+			do_action( 'wp_login', $user->user_login, $user ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound
+
 			$payload = [
 				'authToken'              => TokenManager::get_auth_token( $user ),
 				'authTokenExpiration'    => User::get_auth_token_expiration( $user->ID ),


### PR DESCRIPTION
<!--
Thanks for taking the time to submit a Pull Request.
-->

## What
<!-- In a few words, what does this PR actually change -->

This pr calls `do_action( 'wp_login' )` after the user is successfully set. 

## Why
<!-- Why is this PR necessary? Please any existing previous issue(s) or PR(s) and include a short summary here, too -->

Usually that action is called by `wp_signon()`, which we dont call.

## How
<!-- How is your PR addressing the issue at hand? What are the implementation details?  -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

## Additional Info
<!-- Please include any relevant logs, error output, GraphiQL screenshots, etc -->

## Checklist:
<!-- We encourage you to complete this checklist to the best of your abilities. If you can't do everything, that's okay too.  -->
- [x] My code is tested to the best of my abilities.
- [x] My code follows the WordPress Coding Standards. <!-- Check code: `composer run check-cs`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/ -->
- [x] I have added unit tests to verify the code works as intended.
- [x] I included the relevant changes in CHANGELOG.md
