### PR TITLE
dev: expose `useAuthenticationCookie` to schema

### DIFF
--- a/src/Auth/ProviderConfig/ProviderConfigStaticTrait.php
+++ b/src/Auth/ProviderConfig/ProviderConfigStaticTrait.php
@@ -130,9 +130,13 @@ trait ProviderConfigStaticTrait {
 	 */
 	public static function default_login_options_fields() : array {
 		$fields = [
-			'createUserIfNoneExists' => [
+			'createUserIfNoneExists'  => [
 				'type'        => 'Boolean',
 				'description' => __( 'Whether to create users if none exist.', 'wp-graphql-headless-login' ),
+			],
+			'useAuthenticationCookie' => [
+				'type'        => 'Boolean',
+				'description' => __( 'Whether to set a WordPress authentication cookie on successful login.', 'wp-graphql-headless-login' ),
 			],
 		];
 


### PR DESCRIPTION
<!--
Thanks for taking the time to submit a Pull Request.
-->

## What
<!-- In a few words, what does this PR actually change -->
Adds `useAuthenticationCookie` GraphQL field to `LoginOptions`.

## Why
<!-- Why is this PR necessary? Please any existing previous issue(s) or PR(s) and include a short summary here, too -->
This was unintentionally excluded from #28 

## How
<!-- How is your PR addressing the issue at hand? What are the implementation details?  -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

## Additional Info
<!-- Please include any relevant logs, error output, GraphiQL screenshots, etc -->

## Checklist:
<!-- We encourage you to complete this checklist to the best of your abilities. If you can't do everything, that's okay too.  -->
- [x] My code is tested to the best of my abilities.
- [x] My code follows the WordPress Coding Standards. <!-- Check code: `composer run check-cs`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/ -->
- [x] I have added unit tests to verify the code works as intended.
- [x] I included the relevant changes in CHANGELOG.md
