### PR TITLE
fix: Return `401` if TokenManager::validate_token() finds a `user_id` of `0`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and this project adheres to a modified version of [Semantic Versioning](./README
 - feat: Add settings to set a WP authentication cookie on successful login.
 - feat: Add support for WPGraphQL for WooCommerce.
 
+### Fixed
+- fix: Return `401` for user ID of `0` when validating authentication tokens.
+
+
 ### Changed
 - dev: Trigger `wp_login` action on successful login.
 

--- a/src/Auth/TokenManager.php
+++ b/src/Auth/TokenManager.php
@@ -466,7 +466,7 @@ class TokenManager {
 		}
 
 		// Validate the user Id.
-		if ( ! isset( $token->data->user->id ) ) {
+		if ( empty( $token->data->user->id ) ) {
 			self::set_status( 401 );
 			return new WP_Error( 'invalid-jwt', __( 'User ID not found in the token.', 'wp-graphql-headless-login' ) );
 		}


### PR DESCRIPTION
<!--
Thanks for taking the time to submit a Pull Request.
-->

## What
This PR fixes an issue where a `user_id` of `0` would pass the token validation in `TokenManager::validate_token()`.

## Why
<!-- Why is this PR necessary? Please any existing previous issue(s) or PR(s) and include a short summary here, too -->

## How
<!-- How is your PR addressing the issue at hand? What are the implementation details?  -->
Switch `isset()` to `! empty()` in conditional.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

## Additional Info
<!-- Please include any relevant logs, error output, GraphiQL screenshots, etc -->

## Checklist:
<!-- We encourage you to complete this checklist to the best of your abilities. If you can't do everything, that's okay too.  -->
- [x] My code is tested to the best of my abilities.
- [x] My code follows the WordPress Coding Standards. <!-- Check code: `composer run check-cs`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/ -->
- [x] I have added unit tests to verify the code works as intended.
- [x] I included the relevant changes in CHANGELOG.md
