### PR TITLE
fix: use WPGraphQL::debug() over `GRAPHQL_DEBUG` constant when adding headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to a modified version of [Semantic Versioning](./README
 
 ### Fixed
 - fix: Return `401` for user ID of `0` when validating authentication tokens.
+- fix: use `WPGraphQL::debug()` instead of constant when adding headers.
 
 
 ### Changed

--- a/src/CoreSchemaFilters.php
+++ b/src/CoreSchemaFilters.php
@@ -8,6 +8,7 @@
 namespace WPGraphQL\Login;
 
 use GraphQL\Error\UserError;
+use WPGraphQL;
 use WPGraphQL\Login\Auth\TokenManager;
 use WPGraphQL\Login\Model\User;
 use WPGraphQL\Login\Vendor\AxeWP\GraphQL\Interfaces\Registrable;
@@ -77,8 +78,8 @@ class CoreSchemaFilters implements Registrable {
 	 * @param array $headers the headers to send.
 	 */
 	public static function add_tokens_to_graphql_response_headers( $headers ) : array {
-		// Bail early if not ssl or if debugging is enabled.
-		if ( ! is_ssl() && ( ! defined( 'GRAPHQL_DEBUG' ) || true !== GRAPHQL_DEBUG ) ) {
+		// Bail early if not ssl or if debugging is disabled.
+		if ( ! is_ssl() && false === WPGraphQL::debug() ) {
 			return $headers;
 		}
 


### PR DESCRIPTION
<!--
Thanks for taking the time to submit a Pull Request.
-->

## What
<!-- In a few words, what does this PR actually change -->
This PR changes the conditional for adding tokens to the header response to use `WPGraphQL::debug()` instead of the `GRAPHQL_DEBUG` constant.

## Why
<!-- Why is this PR necessary? Please any existing previous issue(s) or PR(s) and include a short summary here, too -->
So headers can be sent when using the backend setting or WP filter to set WPGraphQL debugging.

## How
<!-- How is your PR addressing the issue at hand? What are the implementation details?  -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

## Additional Info
<!-- Please include any relevant logs, error output, GraphiQL screenshots, etc -->

## Checklist:
<!-- We encourage you to complete this checklist to the best of your abilities. If you can't do everything, that's okay too.  -->
- [x] My code is tested to the best of my abilities.
- [x] My code follows the WordPress Coding Standards. <!-- Check code: `composer run check-cs`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/ -->
- [x] I have added unit tests to verify the code works as intended.
- [x] I included the relevant changes in CHANGELOG.md
