### PR TITLE
fix: check for truthy values when using `graphql_get_login_setting()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to a modified version of [Semantic Versioning](./README
 - feat: Add support for WPGraphQL for WooCommerce.
 
 ### Fixed
+- fix: Check for truthy values when using `graphql_get_login_setting()`.
 - fix: Return `401` for user ID of `0` when validating authentication tokens.
 - fix: use `WPGraphQL::debug()` instead of constant when adding headers.
 

--- a/deactivation.php
+++ b/deactivation.php
@@ -34,7 +34,7 @@ function graphql_login_delete_data() : void {
 	$delete_data = graphql_login_get_setting( 'delete_data_on_deactivate' );
 
 	// Bail if not set to delete.
-	if ( true !== $delete_data ) {
+	if ( empty( $delete_data ) ) {
 		return;
 	}
 

--- a/src/Model/User.php
+++ b/src/Model/User.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Extends the User Model with Authentic
+ * Extends the User Model with authentication data.
  *
  * @package WPGraphQL\Login\Model
  */

--- a/src/Mutation/LoginWithPassword.php
+++ b/src/Mutation/LoginWithPassword.php
@@ -90,7 +90,8 @@ class LoginWithPassword extends MutationType {
 			wp_set_current_user( $user->ID );
 
 			// Set the auth cookie if enabled in the settings.
-			if ( true === graphql_login_get_setting( 'password_use_auth_cookie', false ) ) {
+			if ( ! empty( graphql_login_get_setting( 'password_use_auth_cookie', false ) ) ) {
+				wp_clear_auth_cookie();
 				wp_set_auth_cookie( $user->ID );
 			}
 

--- a/src/Utils/Utils.php
+++ b/src/Utils/Utils.php
@@ -31,6 +31,10 @@ class Utils {
 	/**
 	 * Gets a single plugin setting.
 	 *
+	 * Uses get_option() which means scalars are converted into strings.
+	 *
+	 * @see https://developer.wordpress.org/reference/functions/get_option/#return
+	 *
 	 * @param string      $option_name The name of the setting.
 	 * @param mixed|false $default The default value. Optional. Default false.
 	 *


### PR DESCRIPTION
<!--
Thanks for taking the time to submit a Pull Request.
-->

## What
<!-- In a few words, what does this PR actually change -->
This PR refactors the code using `graphql_get_login_setting()` to check for a value's truthiness

## Why
<!-- Why is this PR necessary? Please any existing previous issue(s) or PR(s) and include a short summary here, too -->
`get_option()` returns strings instead of scalars like `true` and `false`, which caused strict checks to fail.

## How
<!-- How is your PR addressing the issue at hand? What are the implementation details?  -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

## Additional Info
<!-- Please include any relevant logs, error output, GraphiQL screenshots, etc -->

## Checklist:
<!-- We encourage you to complete this checklist to the best of your abilities. If you can't do everything, that's okay too.  -->
- [x] My code is tested to the best of my abilities.
- [x] My code follows the WordPress Coding Standards. <!-- Check code: `composer run check-cs`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/ -->
- [x] I have added unit tests to verify the code works as intended.
- [x] I included the relevant changes in CHANGELOG.md
