### PR TITLE
fix: get `User` model when resolving custom user type

### DIFF
--- a/src/Type/WPObject/AuthenticationData.php
+++ b/src/Type/WPObject/AuthenticationData.php
@@ -8,6 +8,7 @@
 namespace WPGraphQL\Login\Type\WPObject;
 
 use WPGraphQL\Login\Vendor\AxeWP\GraphQL\Abstracts\ObjectType;
+use WPGraphQL\Model\User;
 
 /**
  * Class - AuthenticationData
@@ -34,8 +35,15 @@ class AuthenticationData extends ObjectType {
 				[
 					'type'        => self::get_type_name(),
 					'description' => __( 'Headless Login authentication data.', 'wp-graphql-headless-login' ),
-					'resolve'     => static function ( $user ) {
-						return $user;
+					'resolve'     => static function ( $source ) {
+						if ( ! $source instanceof User && isset( $source->ID ) ) {
+							$user = get_user_by( 'ID', $source->ID );
+
+							if ( $user instanceof \WP_User ) {
+								return new User( $user );
+							}
+						}
+						return $source;
 					},
 				]
 			);


### PR DESCRIPTION
<!--
Thanks for taking the time to submit a Pull Request.
-->

## What
<!-- In a few words, what does this PR actually change -->
Tries to coerce non-core Models into a `Model\User` when resolving for `AuthenticationData`

## Why
<!-- Why is this PR necessary? Please any existing previous issue(s) or PR(s) and include a short summary here, too -->
Fixes an oversight in #30 :
The WooGraphQL `customer` model doesn't extend the `User`, and this generic shim seems like the best approach to supporting other custom types defined by the `graphql_login_user_types` filter.

## How
<!-- How is your PR addressing the issue at hand? What are the implementation details?  -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

## Additional Info
<!-- Please include any relevant logs, error output, GraphiQL screenshots, etc -->

## Checklist:
<!-- We encourage you to complete this checklist to the best of your abilities. If you can't do everything, that's okay too.  -->
- [x] My code is tested to the best of my abilities.
- [x] My code follows the WordPress Coding Standards. <!-- Check code: `composer run check-cs`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/ -->
- [x] I have added unit tests to verify the code works as intended.
- [x] I included the relevant changes in CHANGELOG.md
