### PR TITLE
fix: Don't overwrite existing `Access-Control-Expose-Headers` when adding `X-WPGraphQL-Login-Refresh-Token`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to a modified version of [Semantic Versioning](./README
 - feat: Add support for WPGraphQL for WooCommerce.
 
 ### Fixed
+- fix: Don't overwrite existing `Access-Control-Expose-Headers` when adding `X-WPGraphQL-Login-Refresh-Token`.
 - fix: Check for truthy values when using `graphql_get_login_setting()`.
 - fix: Return `401` for user ID of `0` when validating authentication tokens.
 - fix: use `WPGraphQL::debug()` instead of constant when adding headers.

--- a/src/CoreSchemaFilters.php
+++ b/src/CoreSchemaFilters.php
@@ -29,7 +29,7 @@ class CoreSchemaFilters implements Registrable {
 		add_filter( 'graphql_login_signed_token', [ __CLASS__, 'check_if_secret_is_revoked' ], 10, 2 );
 		// Filter the GraphQL response headers.
 		add_filter( 'graphql_response_headers_to_send', [ __CLASS__, 'add_tokens_to_graphql_response_headers' ] );
-		add_filter( 'graphql_response_headers_to_send', [ __CLASS__, 'add_auth_headers_to_response' ] );
+		add_filter( 'graphql_response_headers_to_send', [ __CLASS__, 'add_refresh_token_to_headers' ] );
 		/**
 		 * Add Auth Headers to REST REQUEST responses
 		 *
@@ -121,8 +121,12 @@ class CoreSchemaFilters implements Registrable {
 	 *
 	 * @param array $headers The existing response headers.
 	 */
-	public static function add_auth_headers_to_response( array $headers ) : array {
-		$headers['Access-Control-Expose-Headers'] = 'X-WPGraphQL-Login-Refresh-Token';
+	public static function add_refresh_token_to_headers( array $headers ) : array {
+		if ( empty( $headers['Access-Control-Expose-Headers'] ) ) {
+			$headers['Access-Control-Expose-Headers'] = 'X-WPGraphQL-Login-Refresh-Token';
+		} else {
+			$headers['Access-Control-Expose-Headers'] .= ', X-WPGraphQL-Login-Refresh-Token';
+		}
 
 		return $headers;
 	}


### PR DESCRIPTION
<!--
Thanks for taking the time to submit a Pull Request.
-->

## What
<!-- In a few words, what does this PR actually change -->
This PR fixes a bug where adding the `X-WPGraphQL-Login-Refresh-Token` to `Access-Control-Expose-Headers` would overwrite existing values.

## Why
<!-- Why is this PR necessary? Please any existing previous issue(s) or PR(s) and include a short summary here, too -->

## How
<!-- How is your PR addressing the issue at hand? What are the implementation details?  -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

## Additional Info
<!-- Please include any relevant logs, error output, GraphiQL screenshots, etc -->

## Checklist:
<!-- We encourage you to complete this checklist to the best of your abilities. If you can't do everything, that's okay too.  -->
- [x] My code is tested to the best of my abilities.
- [x] My code follows the WordPress Coding Standards. <!-- Check code: `composer run check-cs`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/ -->
- [x] I have added unit tests to verify the code works as intended.
- [x] I included the relevant changes in CHANGELOG.md
