### PR TITLE
dev: fix and refine request headers logic

### DIFF
--- a/tests/functional/AuthenticatedQueryCest.php
+++ b/tests/functional/AuthenticatedQueryCest.php
@@ -1,13 +1,8 @@
 <?php
 
 use WPGraphQL\Login\Admin\Settings\AccessControlSettings;
-use WPGraphQL\Login\Admin\Settings\PluginSettings;
-use WPGraphQL\Login\Auth\TokenManager;
-
-use function Codeception\Extension\codecept_log;
 
 class AuthenticatedQueryCest {
-
 
 	public function testQueryWithValidHeaders( FunctionalTester $I ) {
 		$I->wantTo( 'Query with valid authentication headers' );


### PR DESCRIPTION
<!--
Thanks for taking the time to submit a Pull Request.
-->

## What
<!-- In a few words, what does this PR actually change -->
This PR refines #45 by refactoring the way the request headers are sent.

Specifically:
- The `Vary: Origin` header is now set if there are multiple possible allowed origins for the request.
- `X-WPGraphQL-Login-Token` is now included in `Access-Control-Allow-Headers` and excluded from `Access-Control-Expose-Headers`.
- `X-WPGraphQL-Login-Refresh-Token` is now only included in `Access-Control-Expose-Headers` if a valid refresh token is returned in the response.
## Why
<!-- Why is this PR necessary? Please any existing previous issue(s) or PR(s) and include a short summary here, too -->

## How
<!-- How is your PR addressing the issue at hand? What are the implementation details?  -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

## Additional Info
<!-- Please include any relevant logs, error output, GraphiQL screenshots, etc -->

## Checklist:
<!-- We encourage you to complete this checklist to the best of your abilities. If you can't do everything, that's okay too.  -->
- [x] My code is tested to the best of my abilities.
- [x] My code follows the WordPress Coding Standards. <!-- Check code: `composer run check-cs`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/ -->
- [x] I have added unit tests to verify the code works as intended.
- [x] I included the relevant changes in CHANGELOG.md
