### PR TITLE
feat: add Site Token provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to a modified version of [Semantic Versioning](./README
 
 ## Unreleased
 - feat!: Remove `loginWithPassword` mutation in favor of Password provider.
+- feat: Add Site Token provider.
 - feat: Add support for setting Access Control headers.
 - dev!: Refactor settings page frontend components and app logic.
 - dev!: Refactor `ProviderConfig` methods.

--- a/src/Auth/ProviderConfig/SiteToken.php
+++ b/src/Auth/ProviderConfig/SiteToken.php
@@ -1,0 +1,168 @@
+<?php
+/**
+ * The Site Token provider class.
+ *
+ * @package WPGraphQL\Login\Auth\ProviderConfig
+ * @since @todo
+ */
+
+namespace WPGraphQL\Login\Auth\ProviderConfig;
+
+use GraphQL\Error\UserError;
+use WPGraphQL\Login\Auth\User;
+use WPGraphQL\Login\Utils\Utils;
+
+/**
+ * Class - SiteToken
+ */
+class SiteToken extends ProviderConfig {
+	/**
+	 * The provider options as stored in the database.
+	 *
+	 * @var array
+	 */
+	protected array $options;
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function __construct() {
+		$this->options = Utils::get_provider_settings( static::get_slug() );
+
+		parent::__construct();
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public static function get_type() : string {
+		return 'siteToken';
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public static function get_name() : string {
+		return __( 'Site Token', 'wp-graphql-headless-login' );
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public static function get_slug() : string {
+		return 'siteToken';
+	}
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @return array|\WP_Error
+	 */
+	public function authenticate_and_get_user_data( array $input ) {
+		// Get the args from the input.
+		$args = $this->prepare_mutation_input( $input );
+
+		// convert to valid $_SERVER key.
+		$header_key = ! empty( $this->options['clientOptions']['headerKey'] ) ? strtoupper( str_replace( '-', '_', $this->options['clientOptions']['headerKey'] ) ) : '';
+
+		if ( empty( $header_key ) ) {
+			return new \WP_Error(
+				'graphql-headless-login-missing-header-key',
+				__( 'Header key for site token authentication is not defined.', 'wp-graphql-headless-login' )
+			);
+		}
+
+		$secret = $_SERVER[ 'HTTP_' . $header_key ] ?? '';
+
+		if ( empty( $secret ) ) {
+			return new \WP_Error(
+				'graphql-headless-login-missing-header-token',
+				__( 'Missing site token in custom header.', 'wp-graphql-headless-login' )
+			);
+		}
+
+		if ( $secret !== $this->options['clientOptions']['secretKey'] ) {
+			return new \WP_Error(
+				'graphql-headless-login-invalid-header-token',
+				__( 'Invalid site token.', 'wp-graphql-headless-login' )
+			);
+		}
+
+		return $args;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @param array $user_data The user data.
+	 *
+	 * @return \WP_User|false
+	 */
+	public function get_user_from_data( $user_data ) {
+		if ( empty( $user_data['subject_identity'] ) ) {
+			return false;
+		}
+
+		$meta_key = $this->options['loginOptions']['metaKey'] ?? 'user_email';
+
+		return User::get_user_by( $meta_key, $user_data['subject_identity'] );
+	}
+
+	/**
+	 * {@inheritdoc}
+	 *
+	 * @return array{subject_identity: ?string}
+	 *
+	 * @throws UserError
+	 */
+	protected function prepare_mutation_input( array $input ) : array {
+		if ( ! isset( $input['identity'] ) ) {
+			throw new UserError(
+				__( 'The SITE_TOKEN provider requires the use of the `identity` input arg.', 'wp-graphql-headless-login' )
+			);
+		}
+
+		$args = [
+			'subject_identity' => ! empty( $input['identity'] ) ? sanitize_text_field( $input['identity'] ) : null,
+		];
+
+		return $args;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	protected static function client_options_schema() : array {
+		return [
+			'headerKey' => [
+				'type'        => 'string',
+				'label'       => __( 'Header Key', 'wp-graphql-headless-login' ),
+				'description' => __( 'The custom header that will be used to store the site access token.', 'wp-graphql-headless-login' ),
+				'help'        => __( 'The custom header that will be used to store the site access token. The header should only be set on a SERVER-SIDE request. E.g. `X-My-Site-Token`', 'wp-graphql-headless-login' ),
+				'order'       => 1,
+			],
+			'secretKey' => [
+				'type'        => 'string',
+				'label'       => __( 'Site Secret', 'wp-graphql-headless-login' ),
+				'description' => __( 'The secret used to authenticate the site token.', 'wp-graphql-headless-login' ),
+				'help'        => __( 'The secret used to authenticate the site token. This should be the same as the value you set on your custom Header key.  The secret should only be set on a SERVER-SIDE request.', 'wp-graphql-headless-login' ),
+				'order'       => 2,
+			],
+		];
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	protected static function login_options_schema(): array {
+		return [
+			'metaKey' => [
+				'type'        => 'string',
+				'description' => __( 'The User meta key to check for the identity', 'wp-graphql-headless-login' ),
+				'default'     => 'email',
+				'help'        => __( 'The WP_User key to check for the identity. Accepts `id`, `slug`, `email`, `login`, or a custom meta field.', 'wp-graphql-headless-login' ),
+				'order'       => 1,
+			],
+		];
+	}
+}

--- a/src/Auth/ProviderConfig/SiteToken.php
+++ b/src/Auth/ProviderConfig/SiteToken.php
@@ -81,7 +81,7 @@ class SiteToken extends ProviderConfig {
 			);
 		}
 
-		if ( $secret !== $this->options['clientOptions']['secretKey'] ) {
+		if ( ! isset( $this->options['clientOptions']['secretKey'] ) || $secret !== $this->options['clientOptions']['secretKey'] ) {
 			return new \WP_Error(
 				'graphql-headless-login-invalid-header-token',
 				__( 'Invalid site token.', 'wp-graphql-headless-login' )

--- a/src/Auth/ProviderRegistry.php
+++ b/src/Auth/ProviderRegistry.php
@@ -16,6 +16,7 @@ use WPGraphQL\Login\Auth\ProviderConfig\OAuth2\Google;
 use WPGraphQL\Login\Auth\ProviderConfig\OAuth2\Instagram;
 use WPGraphQL\Login\Auth\ProviderConfig\OAuth2\LinkedIn;
 use WPGraphQL\Login\Auth\ProviderConfig\Password;
+use WPGraphQL\Login\Auth\ProviderConfig\SiteToken;
 
 /**
  * Class - ProviderRegistry
@@ -141,6 +142,7 @@ class ProviderRegistry {
 					'instagram' => Instagram::class,
 					'linkedin'  => LinkedIn::class,
 					'password'  => Password::class,
+					'siteToken' => SiteToken::class,
 				]
 			);
 

--- a/src/Auth/Request.php
+++ b/src/Auth/Request.php
@@ -10,6 +10,7 @@ namespace WPGraphQL\Login\Auth;
 
 use GraphQL\Error\UserError;
 use WPGraphQL;
+use WPGraphQL\Login\Auth\ProviderConfig\SiteToken;
 use WPGraphQL\Login\Utils\Utils;
 
 /**
@@ -245,6 +246,17 @@ class Request {
 		// If headers are already set, merge them.
 		if ( ! empty( $header['Access-Control-Allow-Headers'] ) ) {
 			$headers = array_merge( $headers, explode( ', ', $header['Access-Control-Allow-Headers'] ) );
+		}
+
+		// If the SiteLogin provider is active, then set add the provider's header key.
+		if ( SiteToken::is_enabled() ) {
+			$options = Utils::get_provider_settings( SiteToken::get_slug() );
+
+			$token_header = $options['clientOptions']['headerKey'];
+
+			if ( ! empty( $token_header ) ) {
+				$headers[] = $token_header;
+			}
 		}
 
 		// Add custom headers.

--- a/src/Mutation/Login.php
+++ b/src/Mutation/Login.php
@@ -42,6 +42,10 @@ class Login extends MutationType {
 				'type'        => OAuthProviderResponseInput::get_type_name(),
 				'description' => __( 'The parsed response from an OAuth2 Authentication Provider.', 'wp-graphql-headless-login' ),
 			],
+			'identity'      => [
+				'type'        => 'String',
+				'description' => __( 'The user identity to use when logging in. Required by the SiteToken provider.', 'wp-graphql-headless-login' ),
+			],
 			'provider'      => [
 				'type'        => [ 'non_null' => ProviderEnum::get_type_name() ],
 				'description' => __( 'The Headless Login provider to use when logging in.', 'wp-graphql-headless-login' ),

--- a/tests/functional/SiteTokenAuthenticationCest.php
+++ b/tests/functional/SiteTokenAuthenticationCest.php
@@ -4,7 +4,7 @@ use WPGraphQL\Login\Admin\Settings\AccessControlSettings;
 
 class SiteTokenAuthenticationCest {
 
-	public function _before( AcceptanceTester $I ) {
+	public function _before( FunctionalTester $I ) {
 		$I->set_client_config(
 			'siteToken',
 			[

--- a/tests/functional/SiteTokenAuthenticationCest.php
+++ b/tests/functional/SiteTokenAuthenticationCest.php
@@ -1,0 +1,94 @@
+<?php
+
+use WPGraphQL\Login\Admin\Settings\AccessControlSettings;
+
+class SiteTokenAuthenticationCest {
+
+	public function _before( AcceptanceTester $I ) {
+		$I->set_client_config(
+			'siteToken',
+			[
+				'name'          => 'Site Token',
+				'slug'          => 'siteToken',
+				'order'         => 0,
+				'isEnabled'     => true,
+				'clientOptions' => [
+					'headerKey' => 'X-My-Secret-Auth-Token',
+					'secretKey' => 'some_secret',
+				],
+				'loginOptions'  => [
+					'useAuthenticationCookie' => true,
+					'metaKey'                 => 'email',
+				],
+			]
+		);
+		$I->reset_utils_properties();
+		update_option( AccessControlSettings::$settings_prefix . 'access_control', [] );
+	}
+
+	public function testLoginWithSiteToken( FunctionalTester $I ) {
+		$I->wantTo( 'Test the Site Token provider.' );
+
+		$user_id = $I->haveUserInDatabase(
+			'testuser',
+			'administrator',
+			[
+				'user_pass'  => 'testpass',
+				'user_email' => 'some_email@test.com',
+			]
+		);
+
+		$I->haveGraphQLDebug();
+
+		$query = '
+			mutation LoginWithSiteToken( $identity: String!) {
+				login( input: { identity: $identity, provider: SITETOKEN } ) {
+					authToken
+					authTokenExpiration
+					refreshToken
+					refreshTokenExpiration
+					user {
+						auth {
+							isUserSecretRevoked
+							linkedIdentities {
+								id
+								provider
+							}
+							userSecret
+						}
+						databaseId
+						username
+						email
+					}
+				}
+			}
+		';
+
+		$variables = [
+			'identity' => 'some_email@test.com',
+		];
+
+		$response = $I->sendGraphQLRequest(
+			$query,
+			$variables,
+			[
+				'X-My-Secret-Auth-Token' => 'some_secret',
+			]
+		);
+
+		$I->dontSeeHttpHeader( 'X-My-Secret-Auth-Token' );
+
+		// The query is valid and has no errors.
+		$I->assertArrayNotHasKey( 'errors', $response );
+		$I->assertEmpty( $response['extensions']['debug'] );
+
+		// The response is properly returning data as expected.
+		$I->assertArrayHasKey( 'data', $response );
+		$I->assertNotEmpty( $response['data']['login']['authToken'] );
+		$I->assertNotEmpty( $response['data']['login']['authTokenExpiration'] );
+		$I->assertNotEmpty( $response['data']['login']['refreshToken'] );
+		$I->assertNotEmpty( $response['data']['login']['refreshTokenExpiration'] );
+		$I->assertEquals( 'testuser', $response['data']['login']['user']['username'] );
+		$I->assertEquals( 'some_email@test.com', $response['data']['login']['user']['email'] );
+	}
+}

--- a/tests/wpunit/RequestTest.php
+++ b/tests/wpunit/RequestTest.php
@@ -203,6 +203,22 @@ class RequestTest extends \Codeception\TestCase\WPTestCase {
 	}
 
 	public function testResponseHeadersToSend() : void {
+		$default_client_config = [
+			'name'          => 'Site Token',
+			'slug'          => 'siteToken',
+			'order'         => 0,
+			'isEnabled'     => false,
+			'clientOptions' => [
+				'headerKey' => 'X-My-Secret-Auth-Token',
+				'secretKey' => 'some_secret',
+			],
+			'loginOptions'  => [
+				'useAuthenticationCookie' => true,
+				'metaKey'                 => 'email',
+			],
+		];
+		$this->tester->set_client_config( 'siteToken', $default_client_config );
+
 		$default_headers = [
 			'Access-Control-Allow-Origin'   => '*',
 			'Access-Control-Allow-Headers'  => implode(
@@ -242,6 +258,7 @@ class RequestTest extends \Codeception\TestCase\WPTestCase {
 		$this->assertStringContainsString( 'Content-Type', $actual['Access-Control-Allow-Headers'] );
 		$this->assertStringContainsString( 'X-Custom-Header', $actual['Access-Control-Allow-Headers'] );
 		$this->assertStringContainsString( 'X-WPGraphQL-Login-Refresh-Token', $actual['Access-Control-Allow-Headers'] );
+		$this->assertStringNotContainsString( 'X-My-Secret-Auth-Token', $actual['Access-Control-Allow-Headers'] );
 
 		// Check Vary.
 		$this->assertArrayHasKey( 'Vary', $actual );
@@ -249,7 +266,10 @@ class RequestTest extends \Codeception\TestCase\WPTestCase {
 		$this->assertStringContainsString( 'Origin', $actual['Vary'] );
 
 		// Test with custom headers and explicit origin.
+		$default_client_config['isEnabled'] = true;
+		$this->tester->set_client_config( 'siteToken', $default_client_config );
 		$_SERVER['HTTP_ORIGIN'] = site_url();
+
 		update_option(
 			AccessControlSettings::$settings_prefix . 'access_control',
 			array_merge(
@@ -276,6 +296,7 @@ class RequestTest extends \Codeception\TestCase\WPTestCase {
 		$this->assertStringContainsString( 'X-Custom-Header-2', $actual['Access-Control-Allow-Headers'] );
 		$this->assertStringContainsString( 'X-WPGraphQL-Login-Token', $actual['Access-Control-Allow-Headers'] );
 		$this->assertStringContainsString( 'X-WPGraphQL-Login-Refresh-Token', $actual['Access-Control-Allow-Headers'] );
+		$this->assertStringContainsString( 'X-My-Secret-Auth-Token', $actual['Access-Control-Allow-Headers'] );
 
 		// Check Vary.
 		$this->assertArrayHasKey( 'Vary', $actual );

--- a/tests/wpunit/SiteTokenProviderMutationsTest.php
+++ b/tests/wpunit/SiteTokenProviderMutationsTest.php
@@ -3,7 +3,7 @@
  * Tests Login mutation
  */
 
-class PasswordProviderMutationsTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
+class SiteTokenProviderMutationsTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 
 	public $tester;
 	public $admin;
@@ -31,15 +31,21 @@ class PasswordProviderMutationsTest extends \Tests\WPGraphQL\TestCase\WPGraphQLT
 
 		// Set the FB provider config.
 		$this->provider_config = [
-			'name'          => 'Password',
-			'slug'          => 'password',
+			'name'          => 'Site Token',
+			'slug'          => 'siteToken',
 			'order'         => 0,
 			'isEnabled'     => true,
-			'clientOptions' => [],
-			'loginOptions'  => [],
+			'clientOptions' => [
+				'headerKey' => 'X-My-Secret-Auth-Token',
+				'secretKey' => 'some_secret',
+			],
+			'loginOptions'  => [
+				'useAuthenticationCookie' => true,
+				'metaKey'                 => 'login',
+			],
 		];
 
-		$this->tester->set_client_config( 'password', $this->provider_config );
+		$this->tester->set_client_config( 'siteToken', $this->provider_config );
 		$this->clearSchema();
 	}
 
@@ -54,10 +60,8 @@ class PasswordProviderMutationsTest extends \Tests\WPGraphQL\TestCase\WPGraphQLT
 
 	public function login_query() : string {
 		return '
-			mutation Login( $username: String!, $password: String! ) {
-				login(
-					input: {credentials: {username: $username, password: $password }, provider: PASSWORD}
-				) {
+			mutation LoginWithSiteToken( $identity: String!) {
+				login( input: { identity: $identity, provider: SITETOKEN } ) {
 					authToken
 					authTokenExpiration
 					refreshToken
@@ -85,34 +89,36 @@ class PasswordProviderMutationsTest extends \Tests\WPGraphQL\TestCase\WPGraphQLT
 	public function testLoginWithNoProvisioning() : void {
 		$query = $this->login_query();
 
-		// Test bad username.
 		$variables = [
-			'username' => 'baduser',
-			'password' => '12345',
+			'identity' => 'test_user',
 		];
 
-		// Test with no user to match.
+		// Test with no header.
 		$actual = $this->graphql( compact( 'query', 'variables' ) );
 
 		$this->assertArrayHasKey( 'errors', $actual );
-		// The error message changes in WP 5.7
-		$this->assertNotEmpty( $actual['errors'][0]['message'] );
+		$this->assertEquals( 'Missing site token in custom header.', $actual['errors'][0]['message'] );
 
-		// Test with bad password.
-		$variables['username'] = 'test_user';
+		// Test with bad header.
+		$_SERVER['HTTP_X_MY_SECRET_AUTH_TOKEN'] = 'bad_secret';
+
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
+		$this->assertArrayHasKey( 'errors', $actual );
+		$this->assertEquals( 'Invalid site token.', $actual['errors'][0]['message'] );
+
+		// Test with bad identity.
+		$_SERVER['HTTP_X_MY_SECRET_AUTH_TOKEN'] = 'some_secret';
+		$variables['identity']                  = 'bad_user';
 
 		$actual = $this->graphql( compact( 'query', 'variables' ) );
 		$this->assertArrayHasKey( 'errors', $actual );
 		$this->assertEquals( 'The user could not be logged in.', $actual['errors'][0]['message'] );
 
-		// Test with correct credentials.
-		$variables['password'] = 'test_password';
-		// Test with user already logged in.
+		// Test user already logged in.
 		wp_set_current_user( $this->test_user );
+		$variables['identity'] = 'test_user';
 
-		$actual = $this->graphql( compact( 'query', 'variables' ) );
-		$this->assertArrayHasKey( 'errors', $actual );
-		$this->assertEquals( 'You are already logged in.', $actual['errors'][0]['message'] );
+		$this->assertEquals( 'The user could not be logged in.', $actual['errors'][0]['message'] );
 
 		// Test with user logged in as someone else.
 		wp_set_current_user( $this->admin );

--- a/vendor/composer/autoload_classmap.php
+++ b/vendor/composer/autoload_classmap.php
@@ -198,6 +198,7 @@ return array(
     'WPGraphQL\\Login\\Auth\\ProviderConfig\\Password' => $baseDir . '/src/Auth/ProviderConfig/Password.php',
     'WPGraphQL\\Login\\Auth\\ProviderConfig\\ProviderConfig' => $baseDir . '/src/Auth/ProviderConfig/ProviderConfig.php',
     'WPGraphQL\\Login\\Auth\\ProviderConfig\\ProviderConfigStaticTrait' => $baseDir . '/src/Auth/ProviderConfig/ProviderConfigStaticTrait.php',
+    'WPGraphQL\\Login\\Auth\\ProviderConfig\\SiteToken' => $baseDir . '/src/Auth/ProviderConfig/SiteToken.php',
     'WPGraphQL\\Login\\Auth\\ProviderRegistry' => $baseDir . '/src/Auth/ProviderRegistry.php',
     'WPGraphQL\\Login\\Auth\\Request' => $baseDir . '/src/Auth/Request.php',
     'WPGraphQL\\Login\\Auth\\TokenManager' => $baseDir . '/src/Auth/TokenManager.php',

--- a/vendor/composer/autoload_static.php
+++ b/vendor/composer/autoload_static.php
@@ -283,6 +283,7 @@ class ComposerStaticInita93c4afb99f9a719d2c5054478acbe58
         'WPGraphQL\\Login\\Auth\\ProviderConfig\\Password' => __DIR__ . '/../..' . '/src/Auth/ProviderConfig/Password.php',
         'WPGraphQL\\Login\\Auth\\ProviderConfig\\ProviderConfig' => __DIR__ . '/../..' . '/src/Auth/ProviderConfig/ProviderConfig.php',
         'WPGraphQL\\Login\\Auth\\ProviderConfig\\ProviderConfigStaticTrait' => __DIR__ . '/../..' . '/src/Auth/ProviderConfig/ProviderConfigStaticTrait.php',
+        'WPGraphQL\\Login\\Auth\\ProviderConfig\\SiteToken' => __DIR__ . '/../..' . '/src/Auth/ProviderConfig/SiteToken.php',
         'WPGraphQL\\Login\\Auth\\ProviderRegistry' => __DIR__ . '/../..' . '/src/Auth/ProviderRegistry.php',
         'WPGraphQL\\Login\\Auth\\Request' => __DIR__ . '/../..' . '/src/Auth/Request.php',
         'WPGraphQL\\Login\\Auth\\TokenManager' => __DIR__ . '/../..' . '/src/Auth/TokenManager.php',

--- a/vendor/composer/installed.php
+++ b/vendor/composer/installed.php
@@ -3,7 +3,7 @@
         'name' => 'axepress/wp-graphql-headless-login',
         'pretty_version' => 'dev-develop',
         'version' => 'dev-develop',
-        'reference' => '25085a64d72c243cb4ec7a411f0bbb7b401d11d4',
+        'reference' => 'a42790eaf31c4463f86c8070e3b7dc322f8eb449',
         'type' => 'wordpress-plugin',
         'install_path' => __DIR__ . '/../../',
         'aliases' => array(),
@@ -13,7 +13,7 @@
         'axepress/wp-graphql-headless-login' => array(
             'pretty_version' => 'dev-develop',
             'version' => 'dev-develop',
-            'reference' => '25085a64d72c243cb4ec7a411f0bbb7b401d11d4',
+            'reference' => 'a42790eaf31c4463f86c8070e3b7dc322f8eb449',
             'type' => 'wordpress-plugin',
             'install_path' => __DIR__ . '/../../',
             'aliases' => array(),


### PR DESCRIPTION
<!--
Thanks for taking the time to submit a Pull Request.
-->

## What
<!-- In a few words, what does this PR actually change -->

This PR adds the Site Token provider, which allows to frontend to use a special header secret to authenticate as _any_ user.

Due to the security implications, the secret should only be added to the header on a server-side request.

## Why
<!-- Why is this PR necessary? Please any existing previous issue(s) or PR(s) and include a short summary here, too -->
To allow easy integration with frontend-first authentication strategies (e.g NextAuth).

## How
<!-- How is your PR addressing the issue at hand? What are the implementation details?  -->
1. User enables the Site Token provider, sets the name of the custom header, the secret key to use, and the user field to use for the identity lookup.
2. The user authenticates with their frontend provider, and uses the returned subject identity in a *server site graphql request*, with the secret set on the header.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

## Additional Info
<!-- Please include any relevant logs, error output, GraphiQL screenshots, etc -->

## Checklist:
<!-- We encourage you to complete this checklist to the best of your abilities. If you can't do everything, that's okay too.  -->
- [x] My code is tested to the best of my abilities.
- [x] My code follows the WordPress Coding Standards. <!-- Check code: `composer run check-cs`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/ -->
- [x] I have added unit tests to verify the code works as intended.
- [x] I included the relevant changes in CHANGELOG.md
