### PR TITLE
fix!: use ProviderConfig::get_slug() for registry keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to a modified version of [Semantic Versioning](./README
 
 ## Unreleased
 
-- fix: Use `ProviderConfig::get_slug()` for Provider registry keys.
+- fix: Use `ProviderConfig::get_slug()` for Provider registry keys. H/t @ryntab and @stephane-segning.
 
 ## [0.0.7] - 2023-03-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to a modified version of [Semantic Versioning](./README
 
 ## Unreleased
 
+- dev!: Rename `OAuth2 (Generic)` provider slug to `oauth2-generic`.
+**Note:** As a result, the `LoginProviderEnum` name for this provider has changed from `GENERIC_OAUTH2` to `OAUTH2_GENERIC`, and `GenericClientOptions` and `GenericLoginOptions` have been renamed to `OAuth2ClientOptions` and `OAuth2LoginOptions`, respectively, and resets the OAuth2 Generic provider settings.
 - fix: Use `ProviderConfig::get_slug()` for Provider registry keys. H/t @ryntab and @stephane-segning.
 
 ## [0.0.7] - 2023-03-24

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to a modified version of [Semantic Versioning](./README
 
 ## Unreleased
 
+- fix: Use `ProviderConfig::get_slug()` for Provider registry keys.
+
 ## [0.0.7] - 2023-03-24
 
 - fix: Only create one notice when the SiteToken mutation cannot be enabled.

--- a/docs/mutations.md
+++ b/docs/mutations.md
@@ -3,7 +3,7 @@
 ## Login with an OAuth2/OpenID authorization response
 ```graphql
 mutation login(
-  $provider: LoginProviderEnum!, # One of the enabled Authentication Provider types. e.g. FACEBOOK, or GENERIC_OAUTH2
+  $provider: LoginProviderEnum!, # One of the enabled Authentication Provider types. e.g. FACEBOOK, or OAUTH2_GENERIC
   $code:     String!,            # The Authorization Code sent by the Authentication Provider to the frontend's callback URI.
   $state:    String,             # A randomly-generated string used to verify the authenticity of the response sent by the Provider.
 ) {

--- a/src/Auth/ProviderConfig/OAuth2/Generic.php
+++ b/src/Auth/ProviderConfig/OAuth2/Generic.php
@@ -32,7 +32,7 @@ class Generic extends OAuth2Config {
 	 * {@inheritDoc}
 	 */
 	public static function get_slug() : string {
-		return 'generic-oauth2';
+		return 'oauth2-generic';
 	}
 
 	/**
@@ -45,7 +45,7 @@ class Generic extends OAuth2Config {
 			'redirectUri'             => $settings['redirectUri'] ?? null,
 			'urlAuthorize'            => ! empty( $settings['urlAuthorize'] ) ? $settings['urlAuthorize'] : null,
 			'urlAccessToken'          => ! empty( $settings['urlAccessToken'] ) ? $settings['urlAccessToken'] : null,
-			'urlResourceOwnerDetails' => ! empty( $settings['urlAccessToken'] ) ? $settings['urlResourceOwnerDetails'] : null,
+			'urlResourceOwnerDetails' => ! empty( $settings['urlResourceOwnerDetails'] ) ? $settings['urlResourceOwnerDetails'] : null,
 			'scope'                   => ! empty( $settings['scope'] ) ? $settings['scope'] : [],
 		];
 	}

--- a/src/Auth/ProviderRegistry.php
+++ b/src/Auth/ProviderRegistry.php
@@ -135,14 +135,14 @@ class ProviderRegistry {
 			$registered_providers = apply_filters(
 				'graphql_login_registered_provider_configs',
 				[
-					'facebook'  => Facebook::class,
-					'generic'   => Generic::class,
-					'github'    => GitHub::class,
-					'google'    => Google::class,
-					'instagram' => Instagram::class,
-					'linkedin'  => LinkedIn::class,
-					'password'  => Password::class,
-					'siteToken' => SiteToken::class,
+					Facebook::get_slug()  => Facebook::class,
+					Generic::get_slug()   => Generic::class,
+					Github::get_slug()    => GitHub::class,
+					Google::get_slug()    => Google::class,
+					Instagram::get_slug() => Instagram::class,
+					LinkedIn::get_slug()  => LinkedIn::class,
+					Password::get_slug()  => Password::class,
+					SiteToken::get_slug() => SiteToken::class,
 				]
 			);
 

--- a/src/Utils/Utils.php
+++ b/src/Utils/Utils.php
@@ -123,6 +123,7 @@ class Utils {
 	public static function get_provider_settings( string $slug ) {
 		if ( ! isset( self::$providers[ $slug ] ) ) {
 			$settings = get_option( ProviderSettings::$settings_prefix . $slug, [] );
+
 			/**
 			 * Filter the provider settings before returning it
 			 *

--- a/tests/wpunit/ProviderMutationsGenericTest.php
+++ b/tests/wpunit/ProviderMutationsGenericTest.php
@@ -66,7 +66,7 @@ class ProviderMutationsGenericTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTe
 		// Set the provider config.
 		$this->provider_config = [
 			'name'          => 'Generic - OAuth2',
-			'slug'          => 'generic-oauth2',
+			'slug'          => 'oauth2-generic',
 			'order'         => 0,
 			'isEnabled'     => true,
 			'clientOptions' => [
@@ -87,12 +87,12 @@ class ProviderMutationsGenericTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTe
 			],
 		];
 
-		$this->tester->set_client_config( 'generic-oauth2', $this->provider_config );
+		$this->tester->set_client_config( 'oauth2-generic', $this->provider_config );
 
 		add_filter(
 			'graphql_login_provider_config_instances',
 			function( $providers ) {
-				$providers['generic-oauth2'] = new FooGenericProviderConfig();
+				$providers['oauth2-generic'] = new FooGenericProviderConfig();
 
 				return $providers;
 			}
@@ -166,14 +166,14 @@ class ProviderMutationsGenericTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTe
 		// Test with no oauthResponse.
 		$variables = [
 			'input' => [
-				'provider' => 'GENERIC_OAUTH2',
+				'provider' => 'OAUTH2_GENERIC',
 			],
 		];
 
 		$actual = $this->graphql( compact( 'query', 'variables' ) );
 
 		$this->assertArrayHasKey( 'errors', $actual );
-		$this->assertEquals( 'The generic-oauth2 provider requires the use of the `oauthResponse` input arg.', $actual['errors'][0]['message'] );
+		$this->assertEquals( 'The oauth2-generic provider requires the use of the `oauthResponse` input arg.', $actual['errors'][0]['message'] );
 
 		// Test with no user to match.
 		$variables['input']['oauthResponse'] = [
@@ -185,7 +185,7 @@ class ProviderMutationsGenericTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTe
 		$this->assertEquals( 'The user could not be logged in.', $actual['errors'][0]['message'] );
 
 		// Test with user to match.
-		User::link_user_identity( $this->test_user, 'generic-oauth2', '12345' );
+		User::link_user_identity( $this->test_user, 'oauth2-generic', '12345' );
 
 		$actual = $this->graphql( compact( 'query', 'variables' ) );
 
@@ -213,7 +213,7 @@ class ProviderMutationsGenericTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTe
 											'linkedIdentities',
 											[
 												$this->expectedField( 'id', '12345' ),
-												$this->expectedField( 'provider', 'GENERIC_OAUTH2' ),
+												$this->expectedField( 'provider', 'OAUTH2_GENERIC' ),
 											],
 											0
 										),
@@ -242,7 +242,7 @@ class ProviderMutationsGenericTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTe
 		$actual = $this->graphql( compact( 'query', 'variables' ) );
 
 		$this->assertArrayHasKey( 'errors', $actual );
-		$this->assertEquals( 'The state returned from the generic-oauth2 response does not match.', $actual['errors'][0]['message'] );
+		$this->assertEquals( 'The state returned from the oauth2-generic response does not match.', $actual['errors'][0]['message'] );
 
 		// test with good state.
 		$variables['input']['oauthResponse']['state'] = 'mock_state';
@@ -274,7 +274,7 @@ class ProviderMutationsGenericTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTe
 											'linkedIdentities',
 											[
 												$this->expectedField( 'id', '12345' ),
-												$this->expectedField( 'provider', 'GENERIC_OAUTH2' ),
+												$this->expectedField( 'provider', 'OAUTH2_GENERIC' ),
 											],
 											0
 										),
@@ -293,7 +293,7 @@ class ProviderMutationsGenericTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTe
 		$config                                      = $this->provider_config;
 		$config['loginOptions']['linkExistingUsers'] = true;
 
-		$this->tester->set_client_config( 'generic-oauth2', $config );
+		$this->tester->set_client_config( 'oauth2-generic', $config );
 
 		$query = $this->login_query();
 
@@ -302,7 +302,7 @@ class ProviderMutationsGenericTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTe
 				'oauthResponse' => [
 					'code' => 'mock_authorization_code',
 				],
-				'provider'      => 'GENERIC_OAUTH2',
+				'provider'      => 'OAUTH2_GENERIC',
 			],
 		];
 
@@ -346,7 +346,7 @@ class ProviderMutationsGenericTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTe
 											'linkedIdentities',
 											[
 												$this->expectedField( 'id', '12345' ),
-												$this->expectedField( 'provider', 'GENERIC_OAUTH2' ),
+												$this->expectedField( 'provider', 'OAUTH2_GENERIC' ),
 											],
 											0
 										),
@@ -379,7 +379,7 @@ class ProviderMutationsGenericTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTe
 			]
 		);
 
-		$this->tester->set_client_config( 'generic-oauth2', $config );
+		$this->tester->set_client_config( 'oauth2-generic', $config );
 
 		$query = $this->login_query();
 
@@ -388,7 +388,7 @@ class ProviderMutationsGenericTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTe
 				'oauthResponse' => [
 					'code' => 'mock_authorization_code',
 				],
-				'provider'      => 'GENERIC_OAUTH2',
+				'provider'      => 'OAUTH2_GENERIC',
 			],
 		];
 
@@ -430,7 +430,7 @@ class ProviderMutationsGenericTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTe
 											'linkedIdentities',
 											[
 												$this->expectedField( 'id', '12345' ),
-												$this->expectedField( 'provider', 'GENERIC_OAUTH2' ),
+												$this->expectedField( 'provider', 'OAUTH2_GENERIC' ),
 											],
 											0
 										),
@@ -460,7 +460,7 @@ class ProviderMutationsGenericTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTe
 				'oauthResponse' => [
 					'code' => 'mock_authorization_code',
 				],
-				'provider'      => 'GENERIC_OAUTH2',
+				'provider'      => 'OAUTH2_GENERIC',
 				'userId'        => $this->test_user,
 			],
 		];
@@ -493,12 +493,12 @@ class ProviderMutationsGenericTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTe
 				'oauthResponse' => [
 					'code' => 'mock_authorization_code',
 				],
-				'provider'      => 'GENERIC_OAUTH2',
+				'provider'      => 'OAUTH2_GENERIC',
 				'userId'        => $this->test_user,
 			],
 		];
 
-		User::link_user_identity( $this->test_user, 'generic-oauth2', '12345' );
+		User::link_user_identity( $this->test_user, 'oauth2-generic', '12345' );
 
 		wp_set_current_user( $this->test_user );
 
@@ -516,14 +516,14 @@ class ProviderMutationsGenericTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTe
 				'oauthResponse' => [
 					'code' => 'mock_authorization_code',
 				],
-				'provider'      => 'GENERIC_OAUTH2',
+				'provider'      => 'OAUTH2_GENERIC',
 				'userId'        => $this->test_user,
 			],
 		];
 
 		$new_user = $this->factory()->user->create();
 
-		User::link_user_identity( $new_user, 'generic-oauth2', '12345' );
+		User::link_user_identity( $new_user, 'oauth2-generic', '12345' );
 
 		wp_set_current_user( $this->test_user );
 
@@ -541,7 +541,7 @@ class ProviderMutationsGenericTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTe
 				'oauthResponse' => [
 					'code' => 'mock_authorization_code',
 				],
-				'provider'      => 'GENERIC_OAUTH2',
+				'provider'      => 'OAUTH2_GENERIC',
 				'userId'        => $this->test_user,
 			],
 		];
@@ -569,7 +569,7 @@ class ProviderMutationsGenericTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTe
 											'linkedIdentities',
 											[
 												$this->expectedField( 'id', '12345' ),
-												$this->expectedField( 'provider', 'GENERIC_OAUTH2' ),
+												$this->expectedField( 'provider', 'OAUTH2_GENERIC' ),
 											],
 											0
 										),


### PR DESCRIPTION
<!--
Thanks for taking the time to submit a Pull Request.
-->

## What
<!-- In a few words, what does this PR actually change -->
Changes the `ProviderRegistery` to use `ProviderConfig::get_slug()` for the provider class keys. This ensures the code will continue to work even if the slug of a `ProviderConfig` gets changed in the future.

## Why
<!-- Why is this PR necessary? Please any existing previous issue(s) or PR(s) and include a short summary here, too -->
Fixes #56 
(caused by the slug for OAuth2 Generic changing in v0.0.7)

## How
<!-- How is your PR addressing the issue at hand? What are the implementation details?  -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

## Additional Info
<!-- Please include any relevant logs, error output, GraphiQL screenshots, etc -->

## Checklist:
<!-- We encourage you to complete this checklist to the best of your abilities. If you can't do everything, that's okay too.  -->
- [x] My code is tested to the best of my abilities.
- [x] My code follows the WordPress Coding Standards. <!-- Check code: `composer run check-cs`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/ -->
- [ ] I have added unit tests to verify the code works as intended.
- [x] I included the relevant changes in CHANGELOG.md
