### PR TITLE
fix: use refresh_user_secret() when revoking on backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to a modified version of [Semantic Versioning](./README.md#updating-and-versioning).
 
+## [Unreleased]
+
+- fix: Use `TokenManager::refresh_user_secret()` when revoking secrets on the backend to prevent `UserError`s for invalid secrets.
+- docs: Rewrite and restructure existing docs.
+
 ## [0.0.8] - 2023-04-05
 
 This release fixes a bug where OAuth2 (Generic) provider settings were not being accessed correctly (#56).

--- a/src/Admin/UserProfile.php
+++ b/src/Admin/UserProfile.php
@@ -336,7 +336,7 @@ class UserProfile {
 		}
 
 		// Revoke the user secret key.
-		$status = TokenManager::revoke_user_secret( $user_id, false );
+		$status = TokenManager::refresh_user_secret( $user_id, true );
 		if ( is_wp_error( $status ) ) {
 			wp_send_json_error(
 				sprintf(


### PR DESCRIPTION
<!--
Thanks for taking the time to submit a Pull Request.
-->

## What
<!-- In a few words, what does this PR actually change -->

 Use `TokenManager::refresh_user_secret()` when revoking secrets on the backend.


## Why
<!-- Why is this PR necessary? Please any existing previous issue(s) or PR(s) and include a short summary here, too -->

Since `TokenManager::revoke_user_secret()` leaves no secret set, this would cause a fatal GraphQL error, instead of a request for reauthorization.

## How
<!-- How is your PR addressing the issue at hand? What are the implementation details?  -->
- fix: Use `TokenManager::refresh_user_secret()` when revoking secrets on the backend to prevent `UserError`s for invalid secrets.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

## Additional Info
<!-- Please include any relevant logs, error output, GraphiQL screenshots, etc -->

## Checklist:
<!-- We encourage you to complete this checklist to the best of your abilities. If you can't do everything, that's okay too.  -->
- [x] My code is tested to the best of my abilities.
- [x] My code follows the WordPress Coding Standards. <!-- Check code: `composer run check-cs`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/ -->
- [x] I have added unit tests to verify the code works as intended.
- [x] I included the relevant changes in CHANGELOG.md
