### PR TITLE
ci: test plugin against 6.2

### DIFF
--- a/.github/workflows/integration-testing.yml
+++ b/.github/workflows/integration-testing.yml
@@ -22,18 +22,15 @@ jobs:
     strategy:
       matrix:
         php: [ '8.1', '8.0', '7.4' ]
-        wordpress: [ '6.1', '6.0', '5.9' ]
+        wordpress: [ '6.2', '6.1', '6.0', '5.9' ]
         include:
           # WooGraphQL isnt compatible with PHP 8.1 yet.
-          - php: '8.0'
-            wordpress: '6.1'
+          - php: '8.1'
+            wordpress: '6.2'
             extensions: 'true'
             coverage: 1
           - php: '8.0'
             wordpress: '6.0'
-            extensions: 'true'
-          - php: '8.0'
-            wordpress: '5.9'
             extensions: 'true'
           # Older versions of WordPress
           - php: '8.0'

--- a/.github/workflows/integration-testing.yml
+++ b/.github/workflows/integration-testing.yml
@@ -24,14 +24,10 @@ jobs:
         php: [ '8.1', '8.0', '7.4' ]
         wordpress: [ '6.2', '6.1', '6.0', '5.9' ]
         include:
-          # WooGraphQL isnt compatible with PHP 8.1 yet.
           - php: '8.1'
             wordpress: '6.2'
             extensions: 'true'
             coverage: 1
-          - php: '8.0'
-            wordpress: '6.0'
-            extensions: 'true'
           # Older versions of WordPress
           - php: '8.0'
             wordpress: '5.8'
@@ -43,6 +39,9 @@ jobs:
             wordpress: '5.7'
           - php: '7.4'
             wordpress: '5.6'
+        exclude:
+          - php: '7.4'
+            wordpress: '6.2'
       fail-fast: false
 
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to a modified version of [Semantic Versioning](./README
 - fix: only start a PHP session if one is not already started.
 - fix: use `parent::register()` in `ClientOptions` and `LoginOptions` interface classes.
 - chore: Update Composer dependencies.
+- ci: Check compatibility with WordPress 6.2
+- ci: Only test extensions against latest WP/PHP version.
 - tests: fix `HttpClient` mocks for headers and body.
 - docs: Rewrite and restructure existing docs.
 

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: axepress, justlevine
 Tags: GraphQL, Gatsby, Headless, WPGraphQL, React, Rest, SSO, Social Login, OAuth, OAuth2, SAML, Authentication, JWT, Login, OpenID
 Requires at least: 5.6
-Tested up to: 6.1.1
+Tested up to: 6.2
 Requires PHP: 7.4
 Requires WPGraphQL: 1.12.0
 Stable tag: 0.0.8

--- a/wp-graphql-headless-login.php
+++ b/wp-graphql-headless-login.php
@@ -11,7 +11,7 @@
  * Text Domain: wp-graphql-headless-login
  * Domain Path: /languages
  * Requires at least: 5.6
- * Tested up to: 6.1.1
+ * Tested up to: 6.2
  * Requires PHP: 7.4
  * Requires Plugins: wp-graphql
  * WPGraphQL requires at least: 1.12.0


### PR DESCRIPTION
<!--
Thanks for taking the time to submit a Pull Request.
-->

## What
<!-- In a few words, what does this PR actually change -->
Tests the plugin against the latest version of WordPress.

Also removes extension testing from v5.9

## Why
<!-- Why is this PR necessary? Please any existing previous issue(s) or PR(s) and include a short summary here, too -->
WC now only supports >6.0

## How
<!-- How is your PR addressing the issue at hand? What are the implementation details?  -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

## Additional Info
<!-- Please include any relevant logs, error output, GraphiQL screenshots, etc -->

## Checklist:
<!-- We encourage you to complete this checklist to the best of your abilities. If you can't do everything, that's okay too.  -->
- [x] My code is tested to the best of my abilities.
- [x] My code follows the WordPress Coding Standards. <!-- Check code: `composer run check-cs`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/ -->
- [x] I have added unit tests to verify the code works as intended.
- [x] I included the relevant changes in CHANGELOG.md
