### PR TITLE
dev: show conflict notice for WPGraphQL CORS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to a modified version of [Semantic Versioning](./README
 - fix: Hide `Password` provider from the list of User Profile identities.
 - fix: only start a PHP session if one is not already started.
 - fix: use `parent::register()` in `ClientOptions` and `LoginOptions` interface classes.
+- dev: show conflict `admin_notice` if WPGraphQL CORS is enabled.
 - chore: Update Composer dependencies.
 - ci: Check compatibility with WordPress 6.2
 - ci: Only test extensions against latest WP/PHP version.

--- a/wp-graphql-headless-login.php
+++ b/wp-graphql-headless-login.php
@@ -113,6 +113,10 @@ if ( ! function_exists( 'graphql_login_plugin_conflicts' ) ) {
 			$conflicts[] = 'WPGraphQL JWT Authentication';
 		}
 
+		if ( class_exists( 'WP_GraphQL_CORS' ) && is_plugin_active( 'wp-graphql-cors/wp-graphql-cors.php' ) ) {
+			$conflicts[] = 'WPGraphQL CORS';
+		}
+
 		return $conflicts;
 	}
 }


### PR DESCRIPTION
<!--
Thanks for taking the time to submit a Pull Request.
-->

## What
<!-- In a few words, what does this PR actually change -->

Shows an `admin_notice` about the conflict with WPGraphQL CORS when both plugins are enabled.

## Why
<!-- Why is this PR necessary? Please any existing previous issue(s) or PR(s) and include a short summary here, too -->
We can't maintain compatibility with their header filters, and their plugin includes a conflicting login/logout mechanism that we cannot easily reuse.

## How
<!-- How is your PR addressing the issue at hand? What are the implementation details?  -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

## Additional Info
<!-- Please include any relevant logs, error output, GraphiQL screenshots, etc -->

## Checklist:
<!-- We encourage you to complete this checklist to the best of your abilities. If you can't do everything, that's okay too.  -->
- [x] My code is tested to the best of my abilities.
- [x] My code follows the WordPress Coding Standards. <!-- Check code: `composer run check-cs`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/ -->
- [x] I have added unit tests to verify the code works as intended.
- [x] I included the relevant changes in CHANGELOG.md
