### PR TITLE
docs: fix woographql example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ and this project adheres to a modified version of [Semantic Versioning](./README
 ## Unreleased
 
 - fix: Restore missing props on the `FormTokenControl` component. Thanks @ArkDouglas for reporting!
-- chore: Update NPM deps
+- chore: Update NPM deps.
+- docs: Fix WooGraphQL example in Server-Side example.
 
 ## [0.0.9] - 2023-04-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to a modified version of [Semantic Versioning](./README
 
 - fix: Restore missing props on the `FormTokenControl` component. Thanks @ArkDouglas for reporting!
 - chore: Update NPM deps.
-- docs: Fix WooGraphQL example in Server-Side example.
+- docs: Fix WooGraphQL example in Server-Side example. Thanks @kidunot89 for the help!
 
 ## [0.0.9] - 2023-04-22
 


### PR DESCRIPTION
<!--
Thanks for taking the time to submit a Pull Request.
-->

## What
<!-- In a few words, what does this PR actually change -->
Fixes the WooGraphQL usage section in the server-side auth docs, to explain the ideal usage.

## Why
<!-- Why is this PR necessary? Please any existing previous issue(s) or PR(s) and include a short summary here, too -->
As pointed out by @kidunot89, the previous example would reset the `woocommerce-session` both when the user logs in, and every time they revalidate.

## How
<!-- How is your PR addressing the issue at hand? What are the implementation details?  -->
Changes recommendation to use `woocommerce-session` header from the get go, and calls out the (apparently) **bad** pattern of using `wooSessionToken`. 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

## Additional Info
<!-- Please include any relevant logs, error output, GraphiQL screenshots, etc -->

## Checklist:
<!-- We encourage you to complete this checklist to the best of your abilities. If you can't do everything, that's okay too.  -->
- [x] My code is tested to the best of my abilities.
- [x] My code follows the WordPress Coding Standards. <!-- Check code: `composer run check-cs`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/ -->
- [x] I have added unit tests to verify the code works as intended.
- [x] I included the relevant changes in CHANGELOG.md
