### PR TITLE
chore: add missing @wordpress/core-data to npm dev-deps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
 				"@typescript-eslint/parser": "^5.59.6",
 				"@wordpress/babel-plugin-import-jsx-pragma": "^4.16.0",
 				"@wordpress/babel-preset-default": "^7.17.0",
+				"@wordpress/core-data": "^6.10.0",
 				"@wordpress/env": "^7.0.0",
 				"@wordpress/eslint-plugin": "^14.6.0",
 				"@wordpress/hooks": "^3.33.0",
@@ -4616,6 +4617,32 @@
 				}
 			}
 		},
+		"node_modules/@wordpress/api-fetch": {
+			"version": "6.30.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-6.30.0.tgz",
+			"integrity": "sha512-QQyrG/oSnw973RJOqrqIkSMGXR3Yt5itY4n76tHNFKihuP/bbrbT2oIn2XkZ8kj5aRC77Aj6XhirGXgtSU+XLA==",
+			"dev": true,
+			"dependencies": {
+				"@babel/runtime": "^7.16.0",
+				"@wordpress/i18n": "^4.33.0",
+				"@wordpress/url": "^3.34.0"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@wordpress/autop": {
+			"version": "3.33.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/autop/-/autop-3.33.0.tgz",
+			"integrity": "sha512-95PIVEQS7U+GAkmSmOaRUGAACTse8O+ciQQfoJKJQXAkhzihX5oG66wjhFt34OxPmxywvvrUc+s3h/W8w0YAyg==",
+			"dev": true,
+			"dependencies": {
+				"@babel/runtime": "^7.16.0"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
 		"node_modules/@wordpress/babel-plugin-import-jsx-pragma": {
 			"version": "4.16.0",
 			"resolved": "https://registry.npmjs.org/@wordpress/babel-plugin-import-jsx-pragma/-/babel-plugin-import-jsx-pragma-4.16.0.tgz",
@@ -4657,6 +4684,121 @@
 			"integrity": "sha512-rvsyihxkJSWKzPLPZ//oBV994TZY7X0mHwuqFvS4S5j2F57JTAM5PbJs2M1B47A7hQ75E2x2NOMizYtjhtYK7g==",
 			"dev": true
 		},
+		"node_modules/@wordpress/blob": {
+			"version": "3.33.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/blob/-/blob-3.33.0.tgz",
+			"integrity": "sha512-Xj0c2TlE17F649WQO2bniXwp3DRc3oZuZZZZ+hMlIO+iLKtX7KLrnJrVD4BGW7Lwc8DX++q9HBLfifolpovI1w==",
+			"dev": true,
+			"dependencies": {
+				"@babel/runtime": "^7.16.0"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@wordpress/block-serialization-default-parser": {
+			"version": "4.33.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/block-serialization-default-parser/-/block-serialization-default-parser-4.33.0.tgz",
+			"integrity": "sha512-CJtz7vaUOFlQGrlu+PLvLyObeG3RhB/Z9nzmJhTgpK5u61+SKVy/zsBk8ypHDLHjLGamv/DS5ZpqQNpJtqpkGg==",
+			"dev": true,
+			"dependencies": {
+				"@babel/runtime": "^7.16.0"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@wordpress/blocks": {
+			"version": "12.10.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/blocks/-/blocks-12.10.0.tgz",
+			"integrity": "sha512-NKMQLLrEmKW7vIRlSDL/BHH5rUVSI+IGeuv2QEpuEy/MqO096EHyBrwIN3+Nm5M7PMuy5Fij4A+xV0qPvYz2yg==",
+			"dev": true,
+			"dependencies": {
+				"@babel/runtime": "^7.16.0",
+				"@wordpress/autop": "^3.33.0",
+				"@wordpress/blob": "^3.33.0",
+				"@wordpress/block-serialization-default-parser": "^4.33.0",
+				"@wordpress/compose": "^6.10.0",
+				"@wordpress/data": "^9.3.0",
+				"@wordpress/deprecated": "^3.33.0",
+				"@wordpress/dom": "^3.33.0",
+				"@wordpress/element": "^5.10.0",
+				"@wordpress/hooks": "^3.33.0",
+				"@wordpress/html-entities": "^3.33.0",
+				"@wordpress/i18n": "^4.33.0",
+				"@wordpress/is-shallow-equal": "^4.33.0",
+				"@wordpress/private-apis": "^0.15.0",
+				"@wordpress/shortcode": "^3.33.0",
+				"change-case": "^4.1.2",
+				"colord": "^2.7.0",
+				"fast-deep-equal": "^3.1.3",
+				"hpq": "^1.3.0",
+				"is-plain-object": "^5.0.0",
+				"lodash": "^4.17.21",
+				"memize": "^1.1.0",
+				"rememo": "^4.0.2",
+				"remove-accents": "^0.4.2",
+				"showdown": "^1.9.1",
+				"simple-html-tokenizer": "^0.5.7",
+				"uuid": "^8.3.0"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0"
+			}
+		},
+		"node_modules/@wordpress/blocks/node_modules/@wordpress/data": {
+			"version": "9.3.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/data/-/data-9.3.0.tgz",
+			"integrity": "sha512-h5ru+aHuDs9X+eXCy2IyFg+E7RvrNd9dOERojuL/kJrJu1lwFZlAYbVSGSCTNMK48iQ1O4zhgTSXOqJTDlVP3Q==",
+			"dev": true,
+			"dependencies": {
+				"@babel/runtime": "^7.16.0",
+				"@wordpress/compose": "^6.10.0",
+				"@wordpress/deprecated": "^3.33.0",
+				"@wordpress/element": "^5.10.0",
+				"@wordpress/is-shallow-equal": "^4.33.0",
+				"@wordpress/priority-queue": "^2.33.0",
+				"@wordpress/private-apis": "^0.15.0",
+				"@wordpress/redux-routine": "^4.33.0",
+				"deepmerge": "^4.3.0",
+				"equivalent-key-map": "^0.2.2",
+				"is-plain-object": "^5.0.0",
+				"is-promise": "^4.0.0",
+				"redux": "^4.1.2",
+				"turbo-combine-reducers": "^1.0.2",
+				"use-memo-one": "^1.1.1"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0"
+			}
+		},
+		"node_modules/@wordpress/blocks/node_modules/@wordpress/private-apis": {
+			"version": "0.15.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/private-apis/-/private-apis-0.15.0.tgz",
+			"integrity": "sha512-MEkMinYbIu/YqtZ1Ou/2yYUVi2CNUpMdw+Grw9w+fOt5V3hmHwzWpLvyMTcWnlkn7XJN43f2WbP4myF0eG2buQ==",
+			"dev": true,
+			"dependencies": {
+				"@babel/runtime": "^7.16.0"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@wordpress/blocks/node_modules/uuid": {
+			"version": "8.3.2",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+			"integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+			"dev": true,
+			"bin": {
+				"uuid": "dist/bin/uuid"
+			}
+		},
 		"node_modules/@wordpress/browserslist-config": {
 			"version": "5.16.0",
 			"resolved": "https://registry.npmjs.org/@wordpress/browserslist-config/-/browserslist-config-5.16.0.tgz",
@@ -4690,6 +4832,87 @@
 			},
 			"peerDependencies": {
 				"react": "^18.0.0"
+			}
+		},
+		"node_modules/@wordpress/core-data": {
+			"version": "6.10.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/core-data/-/core-data-6.10.0.tgz",
+			"integrity": "sha512-2vTPb+k4MYTiYfGWkocmeB2B6MsHI4vSUYK8fCYFZFgHURR9oW51Kfy8Wb3xHT/0MjyW+jA+o7iVPDO8gwV21g==",
+			"dev": true,
+			"dependencies": {
+				"@babel/runtime": "^7.16.0",
+				"@wordpress/api-fetch": "^6.30.0",
+				"@wordpress/blocks": "^12.10.0",
+				"@wordpress/compose": "^6.10.0",
+				"@wordpress/data": "^9.3.0",
+				"@wordpress/deprecated": "^3.33.0",
+				"@wordpress/element": "^5.10.0",
+				"@wordpress/html-entities": "^3.33.0",
+				"@wordpress/i18n": "^4.33.0",
+				"@wordpress/is-shallow-equal": "^4.33.0",
+				"@wordpress/url": "^3.34.0",
+				"change-case": "^4.1.2",
+				"equivalent-key-map": "^0.2.2",
+				"fast-deep-equal": "^3.1.3",
+				"memize": "^1.1.0",
+				"rememo": "^4.0.2",
+				"uuid": "^8.3.0"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0"
+			}
+		},
+		"node_modules/@wordpress/core-data/node_modules/@wordpress/data": {
+			"version": "9.3.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/data/-/data-9.3.0.tgz",
+			"integrity": "sha512-h5ru+aHuDs9X+eXCy2IyFg+E7RvrNd9dOERojuL/kJrJu1lwFZlAYbVSGSCTNMK48iQ1O4zhgTSXOqJTDlVP3Q==",
+			"dev": true,
+			"dependencies": {
+				"@babel/runtime": "^7.16.0",
+				"@wordpress/compose": "^6.10.0",
+				"@wordpress/deprecated": "^3.33.0",
+				"@wordpress/element": "^5.10.0",
+				"@wordpress/is-shallow-equal": "^4.33.0",
+				"@wordpress/priority-queue": "^2.33.0",
+				"@wordpress/private-apis": "^0.15.0",
+				"@wordpress/redux-routine": "^4.33.0",
+				"deepmerge": "^4.3.0",
+				"equivalent-key-map": "^0.2.2",
+				"is-plain-object": "^5.0.0",
+				"is-promise": "^4.0.0",
+				"redux": "^4.1.2",
+				"turbo-combine-reducers": "^1.0.2",
+				"use-memo-one": "^1.1.1"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0"
+			}
+		},
+		"node_modules/@wordpress/core-data/node_modules/@wordpress/private-apis": {
+			"version": "0.15.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/private-apis/-/private-apis-0.15.0.tgz",
+			"integrity": "sha512-MEkMinYbIu/YqtZ1Ou/2yYUVi2CNUpMdw+Grw9w+fOt5V3hmHwzWpLvyMTcWnlkn7XJN43f2WbP4myF0eG2buQ==",
+			"dev": true,
+			"dependencies": {
+				"@babel/runtime": "^7.16.0"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@wordpress/core-data/node_modules/uuid": {
+			"version": "8.3.2",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+			"integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+			"dev": true,
+			"bin": {
+				"uuid": "dist/bin/uuid"
 			}
 		},
 		"node_modules/@wordpress/data": {
@@ -5011,6 +5234,18 @@
 			"version": "3.33.0",
 			"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-3.33.0.tgz",
 			"integrity": "sha512-Fwp67gbEeSTYx/eLHiLl3tKO1SCjBISRvEJn0LEbgTuz0l92TEb46jCymUOzaHAZOxeJLH9LoM6HJA5Tvg1L2Q==",
+			"dependencies": {
+				"@babel/runtime": "^7.16.0"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@wordpress/html-entities": {
+			"version": "3.33.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/html-entities/-/html-entities-3.33.0.tgz",
+			"integrity": "sha512-qZ98FcpEc3xwGoqfYQLwQ4wpkREFqpo9KKwvevrRT3gyHc98fnbbyD6SKisv7pMdXfDDqg70nREcUB1xwMf6jw==",
+			"dev": true,
 			"dependencies": {
 				"@babel/runtime": "^7.16.0"
 			},
@@ -6527,6 +6762,19 @@
 			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
 			"dev": true
 		},
+		"node_modules/@wordpress/shortcode": {
+			"version": "3.33.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/shortcode/-/shortcode-3.33.0.tgz",
+			"integrity": "sha512-QIjK6XaPqUz5DNoPjy4X6tFm+OMmWRTlJb++c/pU8aeSdLE619Rv4bet6BKCxaArHln1zR7uI27+LBnUZ4mMQA==",
+			"dev": true,
+			"dependencies": {
+				"@babel/runtime": "^7.16.0",
+				"memize": "^1.1.0"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
 		"node_modules/@wordpress/stylelint-config": {
 			"version": "21.16.0",
 			"resolved": "https://registry.npmjs.org/@wordpress/stylelint-config/-/stylelint-config-21.16.0.tgz",
@@ -6541,6 +6789,19 @@
 			},
 			"peerDependencies": {
 				"stylelint": "^14.2"
+			}
+		},
+		"node_modules/@wordpress/url": {
+			"version": "3.34.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/url/-/url-3.34.0.tgz",
+			"integrity": "sha512-Zt0kjumpeA0rCQBzzgPX8L2OH2BMdqxr8A2j0cuFw0FBAs945RM7gAHhTZiv5Em7efpY/b6XSh9xI1fdXYEZWg==",
+			"dev": true,
+			"dependencies": {
+				"@babel/runtime": "^7.16.0",
+				"remove-accents": "^0.4.2"
+			},
+			"engines": {
+				"node": ">=12"
 			}
 		},
 		"node_modules/@wordpress/warning": {
@@ -12143,6 +12404,12 @@
 				"readable-stream": "^2.0.1",
 				"wbuf": "^1.1.0"
 			}
+		},
+		"node_modules/hpq": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/hpq/-/hpq-1.4.0.tgz",
+			"integrity": "sha512-ycJQMRaRPBcfnoT1gS5I1XCvbbw9KO94Y0vkwksuOjcJMqNZtb03MF2tCItLI2mQbkZWSSeFinoRDPmjzv4tKg==",
+			"dev": true
 		},
 		"node_modules/hsl-regex": {
 			"version": "1.0.0",
@@ -18728,6 +18995,18 @@
 				"jsesc": "bin/jsesc"
 			}
 		},
+		"node_modules/rememo": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/rememo/-/rememo-4.0.2.tgz",
+			"integrity": "sha512-NVfSP9NstE3QPNs/TnegQY0vnJnstKQSpcrsI2kBTB3dB2PkdfKdTa+abbjMIDqpc63fE5LfjLgfMst0ULMFxQ==",
+			"dev": true
+		},
+		"node_modules/remove-accents": {
+			"version": "0.4.4",
+			"resolved": "https://registry.npmjs.org/remove-accents/-/remove-accents-0.4.4.tgz",
+			"integrity": "sha512-EpFcOa/ISetVHEXqu+VwI96KZBmq+a8LJnGkaeFw45epGlxIZz5dhEEnNZMsQXgORu3qaMoLX4qJCzOik6ytAg==",
+			"dev": true
+		},
 		"node_modules/requestidlecallback": {
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/requestidlecallback/-/requestidlecallback-0.3.0.tgz",
@@ -18751,6 +19030,12 @@
 			"engines": {
 				"node": ">=0.10.0"
 			}
+		},
+		"node_modules/require-main-filename": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+			"integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+			"dev": true
 		},
 		"node_modules/requireindex": {
 			"version": "1.2.0",
@@ -19433,6 +19718,12 @@
 				"node": ">= 0.8.0"
 			}
 		},
+		"node_modules/set-blocking": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+			"integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
+			"dev": true
+		},
 		"node_modules/setprototypeof": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
@@ -19505,6 +19796,198 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/showdown": {
+			"version": "1.9.1",
+			"resolved": "https://registry.npmjs.org/showdown/-/showdown-1.9.1.tgz",
+			"integrity": "sha512-9cGuS382HcvExtf5AHk7Cb4pAeQQ+h0eTr33V1mu+crYWV4KvWAw6el92bDrqGEk5d46Ai/fhbEUwqJ/mTCNEA==",
+			"dev": true,
+			"dependencies": {
+				"yargs": "^14.2"
+			},
+			"bin": {
+				"showdown": "bin/showdown.js"
+			}
+		},
+		"node_modules/showdown/node_modules/ansi-regex": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
+			"integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==",
+			"dev": true,
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/showdown/node_modules/camelcase": {
+			"version": "5.3.1",
+			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+			"integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+			"dev": true,
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/showdown/node_modules/cliui": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
+			"integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
+			"dev": true,
+			"dependencies": {
+				"string-width": "^3.1.0",
+				"strip-ansi": "^5.2.0",
+				"wrap-ansi": "^5.1.0"
+			}
+		},
+		"node_modules/showdown/node_modules/emoji-regex": {
+			"version": "7.0.3",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+			"integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+			"dev": true
+		},
+		"node_modules/showdown/node_modules/find-up": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+			"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+			"dev": true,
+			"dependencies": {
+				"locate-path": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/showdown/node_modules/is-fullwidth-code-point": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+			"integrity": "sha512-VHskAKYM8RfSFXwee5t5cbN5PZeq1Wrh6qd5bkyiXIf6UQcN6w/A0eXM9r6t8d+GYOh+o6ZhiEnb88LN/Y8m2w==",
+			"dev": true,
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/showdown/node_modules/locate-path": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+			"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+			"dev": true,
+			"dependencies": {
+				"p-locate": "^3.0.0",
+				"path-exists": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/showdown/node_modules/p-limit": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+			"integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+			"dev": true,
+			"dependencies": {
+				"p-try": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/showdown/node_modules/p-locate": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+			"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+			"dev": true,
+			"dependencies": {
+				"p-limit": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/showdown/node_modules/path-exists": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+			"integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/showdown/node_modules/string-width": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+			"integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+			"dev": true,
+			"dependencies": {
+				"emoji-regex": "^7.0.1",
+				"is-fullwidth-code-point": "^2.0.0",
+				"strip-ansi": "^5.1.0"
+			},
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/showdown/node_modules/strip-ansi": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+			"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+			"dev": true,
+			"dependencies": {
+				"ansi-regex": "^4.1.0"
+			},
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/showdown/node_modules/wrap-ansi": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
+			"integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
+			"dev": true,
+			"dependencies": {
+				"ansi-styles": "^3.2.0",
+				"string-width": "^3.0.0",
+				"strip-ansi": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/showdown/node_modules/y18n": {
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+			"integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
+			"dev": true
+		},
+		"node_modules/showdown/node_modules/yargs": {
+			"version": "14.2.3",
+			"resolved": "https://registry.npmjs.org/yargs/-/yargs-14.2.3.tgz",
+			"integrity": "sha512-ZbotRWhF+lkjijC/VhmOT9wSgyBQ7+zr13+YLkhfsSiTriYsMzkTUFP18pFhWwBeMa5gUc1MzbhrO6/VB7c9Xg==",
+			"dev": true,
+			"dependencies": {
+				"cliui": "^5.0.0",
+				"decamelize": "^1.2.0",
+				"find-up": "^3.0.0",
+				"get-caller-file": "^2.0.1",
+				"require-directory": "^2.1.1",
+				"require-main-filename": "^2.0.0",
+				"set-blocking": "^2.0.0",
+				"string-width": "^3.0.0",
+				"which-module": "^2.0.0",
+				"y18n": "^4.0.0",
+				"yargs-parser": "^15.0.1"
+			}
+		},
+		"node_modules/showdown/node_modules/yargs-parser": {
+			"version": "15.0.3",
+			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-15.0.3.tgz",
+			"integrity": "sha512-/MVEVjTXy/cGAjdtQf8dW3V9b97bPN7rNn8ETj6BmAQL7ibC7O1Q9SPJbGjgh3SlwoBNXMzj/ZGIj8mBgl12YA==",
+			"dev": true,
+			"dependencies": {
+				"camelcase": "^5.0.0",
+				"decamelize": "^1.2.0"
+			}
+		},
 		"node_modules/side-channel": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
@@ -19539,6 +20022,12 @@
 				"type": "github",
 				"url": "https://github.com/steveukx/git-js?sponsor=1"
 			}
+		},
+		"node_modules/simple-html-tokenizer": {
+			"version": "0.5.11",
+			"resolved": "https://registry.npmjs.org/simple-html-tokenizer/-/simple-html-tokenizer-0.5.11.tgz",
+			"integrity": "sha512-C2WEK/Z3HoSFbYq8tI7ni3eOo/NneSPRoPpcM7WdLjFOArFuyXEjAoCdOC3DgMfRyziZQ1hCNR4mrNdWEvD0og==",
+			"dev": true
 		},
 		"node_modules/simple-swizzle": {
 			"version": "0.2.2",
@@ -22941,6 +23430,12 @@
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
+		},
+		"node_modules/which-module": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.1.tgz",
+			"integrity": "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==",
+			"dev": true
 		},
 		"node_modules/which-typed-array": {
 			"version": "1.1.9",
@@ -26558,6 +27053,26 @@
 			"dev": true,
 			"requires": {}
 		},
+		"@wordpress/api-fetch": {
+			"version": "6.30.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-6.30.0.tgz",
+			"integrity": "sha512-QQyrG/oSnw973RJOqrqIkSMGXR3Yt5itY4n76tHNFKihuP/bbrbT2oIn2XkZ8kj5aRC77Aj6XhirGXgtSU+XLA==",
+			"dev": true,
+			"requires": {
+				"@babel/runtime": "^7.16.0",
+				"@wordpress/i18n": "^4.33.0",
+				"@wordpress/url": "^3.34.0"
+			}
+		},
+		"@wordpress/autop": {
+			"version": "3.33.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/autop/-/autop-3.33.0.tgz",
+			"integrity": "sha512-95PIVEQS7U+GAkmSmOaRUGAACTse8O+ciQQfoJKJQXAkhzihX5oG66wjhFt34OxPmxywvvrUc+s3h/W8w0YAyg==",
+			"dev": true,
+			"requires": {
+				"@babel/runtime": "^7.16.0"
+			}
+		},
 		"@wordpress/babel-plugin-import-jsx-pragma": {
 			"version": "4.16.0",
 			"resolved": "https://registry.npmjs.org/@wordpress/babel-plugin-import-jsx-pragma/-/babel-plugin-import-jsx-pragma-4.16.0.tgz",
@@ -26591,6 +27106,99 @@
 			"integrity": "sha512-rvsyihxkJSWKzPLPZ//oBV994TZY7X0mHwuqFvS4S5j2F57JTAM5PbJs2M1B47A7hQ75E2x2NOMizYtjhtYK7g==",
 			"dev": true
 		},
+		"@wordpress/blob": {
+			"version": "3.33.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/blob/-/blob-3.33.0.tgz",
+			"integrity": "sha512-Xj0c2TlE17F649WQO2bniXwp3DRc3oZuZZZZ+hMlIO+iLKtX7KLrnJrVD4BGW7Lwc8DX++q9HBLfifolpovI1w==",
+			"dev": true,
+			"requires": {
+				"@babel/runtime": "^7.16.0"
+			}
+		},
+		"@wordpress/block-serialization-default-parser": {
+			"version": "4.33.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/block-serialization-default-parser/-/block-serialization-default-parser-4.33.0.tgz",
+			"integrity": "sha512-CJtz7vaUOFlQGrlu+PLvLyObeG3RhB/Z9nzmJhTgpK5u61+SKVy/zsBk8ypHDLHjLGamv/DS5ZpqQNpJtqpkGg==",
+			"dev": true,
+			"requires": {
+				"@babel/runtime": "^7.16.0"
+			}
+		},
+		"@wordpress/blocks": {
+			"version": "12.10.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/blocks/-/blocks-12.10.0.tgz",
+			"integrity": "sha512-NKMQLLrEmKW7vIRlSDL/BHH5rUVSI+IGeuv2QEpuEy/MqO096EHyBrwIN3+Nm5M7PMuy5Fij4A+xV0qPvYz2yg==",
+			"dev": true,
+			"requires": {
+				"@babel/runtime": "^7.16.0",
+				"@wordpress/autop": "^3.33.0",
+				"@wordpress/blob": "^3.33.0",
+				"@wordpress/block-serialization-default-parser": "^4.33.0",
+				"@wordpress/compose": "^6.10.0",
+				"@wordpress/data": "^9.3.0",
+				"@wordpress/deprecated": "^3.33.0",
+				"@wordpress/dom": "^3.33.0",
+				"@wordpress/element": "^5.10.0",
+				"@wordpress/hooks": "^3.33.0",
+				"@wordpress/html-entities": "^3.33.0",
+				"@wordpress/i18n": "^4.33.0",
+				"@wordpress/is-shallow-equal": "^4.33.0",
+				"@wordpress/private-apis": "^0.15.0",
+				"@wordpress/shortcode": "^3.33.0",
+				"change-case": "^4.1.2",
+				"colord": "^2.7.0",
+				"fast-deep-equal": "^3.1.3",
+				"hpq": "^1.3.0",
+				"is-plain-object": "^5.0.0",
+				"lodash": "^4.17.21",
+				"memize": "^1.1.0",
+				"rememo": "^4.0.2",
+				"remove-accents": "^0.4.2",
+				"showdown": "^1.9.1",
+				"simple-html-tokenizer": "^0.5.7",
+				"uuid": "^8.3.0"
+			},
+			"dependencies": {
+				"@wordpress/data": {
+					"version": "9.3.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/data/-/data-9.3.0.tgz",
+					"integrity": "sha512-h5ru+aHuDs9X+eXCy2IyFg+E7RvrNd9dOERojuL/kJrJu1lwFZlAYbVSGSCTNMK48iQ1O4zhgTSXOqJTDlVP3Q==",
+					"dev": true,
+					"requires": {
+						"@babel/runtime": "^7.16.0",
+						"@wordpress/compose": "^6.10.0",
+						"@wordpress/deprecated": "^3.33.0",
+						"@wordpress/element": "^5.10.0",
+						"@wordpress/is-shallow-equal": "^4.33.0",
+						"@wordpress/priority-queue": "^2.33.0",
+						"@wordpress/private-apis": "^0.15.0",
+						"@wordpress/redux-routine": "^4.33.0",
+						"deepmerge": "^4.3.0",
+						"equivalent-key-map": "^0.2.2",
+						"is-plain-object": "^5.0.0",
+						"is-promise": "^4.0.0",
+						"redux": "^4.1.2",
+						"turbo-combine-reducers": "^1.0.2",
+						"use-memo-one": "^1.1.1"
+					}
+				},
+				"@wordpress/private-apis": {
+					"version": "0.15.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/private-apis/-/private-apis-0.15.0.tgz",
+					"integrity": "sha512-MEkMinYbIu/YqtZ1Ou/2yYUVi2CNUpMdw+Grw9w+fOt5V3hmHwzWpLvyMTcWnlkn7XJN43f2WbP4myF0eG2buQ==",
+					"dev": true,
+					"requires": {
+						"@babel/runtime": "^7.16.0"
+					}
+				},
+				"uuid": {
+					"version": "8.3.2",
+					"resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+					"integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+					"dev": true
+				}
+			}
+		},
 		"@wordpress/browserslist-config": {
 			"version": "5.16.0",
 			"resolved": "https://registry.npmjs.org/@wordpress/browserslist-config/-/browserslist-config-5.16.0.tgz",
@@ -26615,6 +27223,71 @@
 				"clipboard": "^2.0.8",
 				"mousetrap": "^1.6.5",
 				"use-memo-one": "^1.1.1"
+			}
+		},
+		"@wordpress/core-data": {
+			"version": "6.10.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/core-data/-/core-data-6.10.0.tgz",
+			"integrity": "sha512-2vTPb+k4MYTiYfGWkocmeB2B6MsHI4vSUYK8fCYFZFgHURR9oW51Kfy8Wb3xHT/0MjyW+jA+o7iVPDO8gwV21g==",
+			"dev": true,
+			"requires": {
+				"@babel/runtime": "^7.16.0",
+				"@wordpress/api-fetch": "^6.30.0",
+				"@wordpress/blocks": "^12.10.0",
+				"@wordpress/compose": "^6.10.0",
+				"@wordpress/data": "^9.3.0",
+				"@wordpress/deprecated": "^3.33.0",
+				"@wordpress/element": "^5.10.0",
+				"@wordpress/html-entities": "^3.33.0",
+				"@wordpress/i18n": "^4.33.0",
+				"@wordpress/is-shallow-equal": "^4.33.0",
+				"@wordpress/url": "^3.34.0",
+				"change-case": "^4.1.2",
+				"equivalent-key-map": "^0.2.2",
+				"fast-deep-equal": "^3.1.3",
+				"memize": "^1.1.0",
+				"rememo": "^4.0.2",
+				"uuid": "^8.3.0"
+			},
+			"dependencies": {
+				"@wordpress/data": {
+					"version": "9.3.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/data/-/data-9.3.0.tgz",
+					"integrity": "sha512-h5ru+aHuDs9X+eXCy2IyFg+E7RvrNd9dOERojuL/kJrJu1lwFZlAYbVSGSCTNMK48iQ1O4zhgTSXOqJTDlVP3Q==",
+					"dev": true,
+					"requires": {
+						"@babel/runtime": "^7.16.0",
+						"@wordpress/compose": "^6.10.0",
+						"@wordpress/deprecated": "^3.33.0",
+						"@wordpress/element": "^5.10.0",
+						"@wordpress/is-shallow-equal": "^4.33.0",
+						"@wordpress/priority-queue": "^2.33.0",
+						"@wordpress/private-apis": "^0.15.0",
+						"@wordpress/redux-routine": "^4.33.0",
+						"deepmerge": "^4.3.0",
+						"equivalent-key-map": "^0.2.2",
+						"is-plain-object": "^5.0.0",
+						"is-promise": "^4.0.0",
+						"redux": "^4.1.2",
+						"turbo-combine-reducers": "^1.0.2",
+						"use-memo-one": "^1.1.1"
+					}
+				},
+				"@wordpress/private-apis": {
+					"version": "0.15.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/private-apis/-/private-apis-0.15.0.tgz",
+					"integrity": "sha512-MEkMinYbIu/YqtZ1Ou/2yYUVi2CNUpMdw+Grw9w+fOt5V3hmHwzWpLvyMTcWnlkn7XJN43f2WbP4myF0eG2buQ==",
+					"dev": true,
+					"requires": {
+						"@babel/runtime": "^7.16.0"
+					}
+				},
+				"uuid": {
+					"version": "8.3.2",
+					"resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+					"integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+					"dev": true
+				}
 			}
 		},
 		"@wordpress/data": {
@@ -26847,6 +27520,15 @@
 			"version": "3.33.0",
 			"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-3.33.0.tgz",
 			"integrity": "sha512-Fwp67gbEeSTYx/eLHiLl3tKO1SCjBISRvEJn0LEbgTuz0l92TEb46jCymUOzaHAZOxeJLH9LoM6HJA5Tvg1L2Q==",
+			"requires": {
+				"@babel/runtime": "^7.16.0"
+			}
+		},
+		"@wordpress/html-entities": {
+			"version": "3.33.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/html-entities/-/html-entities-3.33.0.tgz",
+			"integrity": "sha512-qZ98FcpEc3xwGoqfYQLwQ4wpkREFqpo9KKwvevrRT3gyHc98fnbbyD6SKisv7pMdXfDDqg70nREcUB1xwMf6jw==",
+			"dev": true,
 			"requires": {
 				"@babel/runtime": "^7.16.0"
 			}
@@ -27814,6 +28496,16 @@
 				}
 			}
 		},
+		"@wordpress/shortcode": {
+			"version": "3.33.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/shortcode/-/shortcode-3.33.0.tgz",
+			"integrity": "sha512-QIjK6XaPqUz5DNoPjy4X6tFm+OMmWRTlJb++c/pU8aeSdLE619Rv4bet6BKCxaArHln1zR7uI27+LBnUZ4mMQA==",
+			"dev": true,
+			"requires": {
+				"@babel/runtime": "^7.16.0",
+				"memize": "^1.1.0"
+			}
+		},
 		"@wordpress/stylelint-config": {
 			"version": "21.16.0",
 			"resolved": "https://registry.npmjs.org/@wordpress/stylelint-config/-/stylelint-config-21.16.0.tgz",
@@ -27822,6 +28514,16 @@
 			"requires": {
 				"stylelint-config-recommended": "^6.0.0",
 				"stylelint-config-recommended-scss": "^5.0.2"
+			}
+		},
+		"@wordpress/url": {
+			"version": "3.34.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/url/-/url-3.34.0.tgz",
+			"integrity": "sha512-Zt0kjumpeA0rCQBzzgPX8L2OH2BMdqxr8A2j0cuFw0FBAs945RM7gAHhTZiv5Em7efpY/b6XSh9xI1fdXYEZWg==",
+			"dev": true,
+			"requires": {
+				"@babel/runtime": "^7.16.0",
+				"remove-accents": "^0.4.2"
 			}
 		},
 		"@wordpress/warning": {
@@ -32064,6 +32766,12 @@
 				"readable-stream": "^2.0.1",
 				"wbuf": "^1.1.0"
 			}
+		},
+		"hpq": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/hpq/-/hpq-1.4.0.tgz",
+			"integrity": "sha512-ycJQMRaRPBcfnoT1gS5I1XCvbbw9KO94Y0vkwksuOjcJMqNZtb03MF2tCItLI2mQbkZWSSeFinoRDPmjzv4tKg==",
+			"dev": true
 		},
 		"hsl-regex": {
 			"version": "1.0.0",
@@ -36897,6 +37605,18 @@
 				}
 			}
 		},
+		"rememo": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/rememo/-/rememo-4.0.2.tgz",
+			"integrity": "sha512-NVfSP9NstE3QPNs/TnegQY0vnJnstKQSpcrsI2kBTB3dB2PkdfKdTa+abbjMIDqpc63fE5LfjLgfMst0ULMFxQ==",
+			"dev": true
+		},
+		"remove-accents": {
+			"version": "0.4.4",
+			"resolved": "https://registry.npmjs.org/remove-accents/-/remove-accents-0.4.4.tgz",
+			"integrity": "sha512-EpFcOa/ISetVHEXqu+VwI96KZBmq+a8LJnGkaeFw45epGlxIZz5dhEEnNZMsQXgORu3qaMoLX4qJCzOik6ytAg==",
+			"dev": true
+		},
 		"requestidlecallback": {
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/requestidlecallback/-/requestidlecallback-0.3.0.tgz",
@@ -36913,6 +37633,12 @@
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
 			"integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+			"dev": true
+		},
+		"require-main-filename": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+			"integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
 			"dev": true
 		},
 		"requireindex": {
@@ -37426,6 +38152,12 @@
 				"send": "0.18.0"
 			}
 		},
+		"set-blocking": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+			"integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
+			"dev": true
+		},
 		"setprototypeof": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
@@ -37482,6 +38214,161 @@
 			"integrity": "sha512-6j1W9l1iAs/4xYBI1SYOVZyFcCis9b4KCLQ8fgAGG07QvzaRLVVRQvAy85yNmmZSjYjg4MWh4gNvlPujU/5LpA==",
 			"dev": true
 		},
+		"showdown": {
+			"version": "1.9.1",
+			"resolved": "https://registry.npmjs.org/showdown/-/showdown-1.9.1.tgz",
+			"integrity": "sha512-9cGuS382HcvExtf5AHk7Cb4pAeQQ+h0eTr33V1mu+crYWV4KvWAw6el92bDrqGEk5d46Ai/fhbEUwqJ/mTCNEA==",
+			"dev": true,
+			"requires": {
+				"yargs": "^14.2"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
+					"integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==",
+					"dev": true
+				},
+				"camelcase": {
+					"version": "5.3.1",
+					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+					"integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+					"dev": true
+				},
+				"cliui": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
+					"integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
+					"dev": true,
+					"requires": {
+						"string-width": "^3.1.0",
+						"strip-ansi": "^5.2.0",
+						"wrap-ansi": "^5.1.0"
+					}
+				},
+				"emoji-regex": {
+					"version": "7.0.3",
+					"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+					"integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+					"dev": true
+				},
+				"find-up": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+					"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+					"dev": true,
+					"requires": {
+						"locate-path": "^3.0.0"
+					}
+				},
+				"is-fullwidth-code-point": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+					"integrity": "sha512-VHskAKYM8RfSFXwee5t5cbN5PZeq1Wrh6qd5bkyiXIf6UQcN6w/A0eXM9r6t8d+GYOh+o6ZhiEnb88LN/Y8m2w==",
+					"dev": true
+				},
+				"locate-path": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+					"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+					"dev": true,
+					"requires": {
+						"p-locate": "^3.0.0",
+						"path-exists": "^3.0.0"
+					}
+				},
+				"p-limit": {
+					"version": "2.3.0",
+					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+					"integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+					"dev": true,
+					"requires": {
+						"p-try": "^2.0.0"
+					}
+				},
+				"p-locate": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+					"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+					"dev": true,
+					"requires": {
+						"p-limit": "^2.0.0"
+					}
+				},
+				"path-exists": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+					"integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
+					"dev": true
+				},
+				"string-width": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+					"integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+					"dev": true,
+					"requires": {
+						"emoji-regex": "^7.0.1",
+						"is-fullwidth-code-point": "^2.0.0",
+						"strip-ansi": "^5.1.0"
+					}
+				},
+				"strip-ansi": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+					"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^4.1.0"
+					}
+				},
+				"wrap-ansi": {
+					"version": "5.1.0",
+					"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
+					"integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^3.2.0",
+						"string-width": "^3.0.0",
+						"strip-ansi": "^5.0.0"
+					}
+				},
+				"y18n": {
+					"version": "4.0.3",
+					"resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+					"integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
+					"dev": true
+				},
+				"yargs": {
+					"version": "14.2.3",
+					"resolved": "https://registry.npmjs.org/yargs/-/yargs-14.2.3.tgz",
+					"integrity": "sha512-ZbotRWhF+lkjijC/VhmOT9wSgyBQ7+zr13+YLkhfsSiTriYsMzkTUFP18pFhWwBeMa5gUc1MzbhrO6/VB7c9Xg==",
+					"dev": true,
+					"requires": {
+						"cliui": "^5.0.0",
+						"decamelize": "^1.2.0",
+						"find-up": "^3.0.0",
+						"get-caller-file": "^2.0.1",
+						"require-directory": "^2.1.1",
+						"require-main-filename": "^2.0.0",
+						"set-blocking": "^2.0.0",
+						"string-width": "^3.0.0",
+						"which-module": "^2.0.0",
+						"y18n": "^4.0.0",
+						"yargs-parser": "^15.0.1"
+					}
+				},
+				"yargs-parser": {
+					"version": "15.0.3",
+					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-15.0.3.tgz",
+					"integrity": "sha512-/MVEVjTXy/cGAjdtQf8dW3V9b97bPN7rNn8ETj6BmAQL7ibC7O1Q9SPJbGjgh3SlwoBNXMzj/ZGIj8mBgl12YA==",
+					"dev": true,
+					"requires": {
+						"camelcase": "^5.0.0",
+						"decamelize": "^1.2.0"
+					}
+				}
+			}
+		},
 		"side-channel": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
@@ -37509,6 +38396,12 @@
 				"@kwsites/promise-deferred": "^1.1.1",
 				"debug": "^4.3.4"
 			}
+		},
+		"simple-html-tokenizer": {
+			"version": "0.5.11",
+			"resolved": "https://registry.npmjs.org/simple-html-tokenizer/-/simple-html-tokenizer-0.5.11.tgz",
+			"integrity": "sha512-C2WEK/Z3HoSFbYq8tI7ni3eOo/NneSPRoPpcM7WdLjFOArFuyXEjAoCdOC3DgMfRyziZQ1hCNR4mrNdWEvD0og==",
+			"dev": true
 		},
 		"simple-swizzle": {
 			"version": "0.2.2",
@@ -40201,6 +41094,12 @@
 				"is-weakmap": "^2.0.1",
 				"is-weakset": "^2.0.1"
 			}
+		},
+		"which-module": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.1.tgz",
+			"integrity": "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==",
+			"dev": true
 		},
 		"which-typed-array": {
 			"version": "1.1.9",

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
 		"@typescript-eslint/parser": "^5.59.6",
 		"@wordpress/babel-plugin-import-jsx-pragma": "^4.16.0",
 		"@wordpress/babel-preset-default": "^7.17.0",
+		"@wordpress/core-data": "^6.10.0",
 		"@wordpress/env": "^7.0.0",
 		"@wordpress/eslint-plugin": "^14.6.0",
 		"@wordpress/hooks": "^3.33.0",


### PR DESCRIPTION
<!--
Thanks for taking the time to submit a Pull Request.
-->

## What
<!-- In a few words, what does this PR actually change -->

Addresses a regression in #75 where the `@wordpress/core-data` _types_ were removed but the package itself was not added to the NPM dev dependencies.

## Why
<!-- Why is this PR necessary? Please any existing previous issue(s) or PR(s) and include a short summary here, too -->

## How
<!-- How is your PR addressing the issue at hand? What are the implementation details?  -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

## Additional Info
<!-- Please include any relevant logs, error output, GraphiQL screenshots, etc -->

## Checklist:
<!-- We encourage you to complete this checklist to the best of your abilities. If you can't do everything, that's okay too.  -->
- [x] My code is tested to the best of my abilities.
- [x] My code follows the WordPress Coding Standards. <!-- Check code: `composer run check-cs`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/ -->
- [x] I have added unit tests to verify the code works as intended.
- [x] I included the relevant changes in CHANGELOG.md
