### PR TITLE
fix: use scope separators from Provider library.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to a modified version of [Semantic Versioning](./README.md#updating-and-versioning).
 
 ## Unreleased
+- fix: Let the OAuth2 Provider library handle imploding the `scope`.
 - chore: Update Composer deps.
 - chore: Cleanup PHPCS and PHPStan configurations.
 - ci: Set MariaDB to v10.x in GitHub Actions.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to a modified version of [Semantic Versioning](./README.md#updating-and-versioning).
 
 ## Unreleased
+- feat: Add support for setting a custom `scopeSeparator` for Generic OAuth2 providers. H/t @martinowren for bringing this up!
 - fix: Let the OAuth2 Provider library handle imploding the `scope`.
 - chore: Update Composer deps.
 - chore: Cleanup PHPCS and PHPStan configurations.

--- a/src/Auth/ProviderConfig/OAuth2/Facebook.php
+++ b/src/Auth/ProviderConfig/OAuth2/Facebook.php
@@ -44,7 +44,7 @@ class Facebook extends OAuth2Config {
 			'clientSecret'    => $settings['clientSecret'] ?? null,
 			'redirectUri'     => $settings['redirectUri'] ?? null,
 			'graphApiVersion' => $settings['graphAPIVersion'] ?? 'v15.0',
-			'scope'           => ! empty( $settings['scope'] ) ? implode( ', ', $settings['scope'] ) : [],
+			'scope'           => ! empty( $settings['scope'] ) ? $settings['scope'] : [],
 		];
 	}
 

--- a/src/Auth/ProviderConfig/OAuth2/Generic.php
+++ b/src/Auth/ProviderConfig/OAuth2/Generic.php
@@ -47,6 +47,7 @@ class Generic extends OAuth2Config {
 			'urlAccessToken'          => ! empty( $settings['urlAccessToken'] ) ? $settings['urlAccessToken'] : null,
 			'urlResourceOwnerDetails' => ! empty( $settings['urlResourceOwnerDetails'] ) ? $settings['urlResourceOwnerDetails'] : null,
 			'scope'                   => ! empty( $settings['scope'] ) ? $settings['scope'] : [],
+			'scopeSeparator'          => $settings['scopeSeparator'] ?? ',',
 		];
 	}
 
@@ -83,6 +84,11 @@ class Generic extends OAuth2Config {
 					'type' => 'string',
 				],
 			],
+			'scopeSeparator'          => [
+				'type'        => 'string',
+				'description' => __( 'Scope Separator', 'wp-graphql-headless-login' ),
+				'help'        => __( 'The scope separator to use when building the authorization URL. Defaults to `,`.', 'wp-graphql-headless-login' ),
+			],
 		];
 	}
 
@@ -109,6 +115,10 @@ class Generic extends OAuth2Config {
 			'scope'            => [
 				'type'        => [ 'list_of' => 'String' ],
 				'description' => __( 'The fields to request from the Generic Graph API. See https://developers.facebook.com/docs/graph-api/reference/user for a list of available fields.', 'wp-graphql-headless-login' ),
+			],
+			'scopeSeparator'   => [
+				'type'        => 'String',
+				'description' => __( 'The scope separator to use when building the authorization URL. Defaults to `,`.', 'wp-graphql-headless-login' ),
 			],
 		];
 	}

--- a/src/Auth/ProviderConfig/OAuth2/Instagram.php
+++ b/src/Auth/ProviderConfig/OAuth2/Instagram.php
@@ -43,7 +43,7 @@ class Instagram extends OAuth2Config {
 			'clientId'     => $settings['clientId'] ?? null,
 			'clientSecret' => $settings['clientSecret'] ?? null,
 			'redirectUri'  => $settings['redirectUri'] ?? null,
-			'scope'        => ! empty( $settings['scope'] ) ? implode( ', ', $settings['scope'] ) : [],
+			'scope'        => ! empty( $settings['scope'] ) ? $settings['scope'] : [],
 		];
 	}
 


### PR DESCRIPTION
<!--
Thanks for taking the time to submit a Pull Request.
-->

## What
<!-- In a few words, what does this PR actually change -->
This PR stops imploding the ProviderConfg's `scope` setting array, instead deferring that responsibility to the underlying OAuth2 Provider. Additionally, a new `scopeSeparator` option has been added to the OAuth2 Generic client.

Note: this _does not_ fix the bug where the `Scope` field itself is missing.

## Why
<!-- Why is this PR necessary? Please any existing previous issue(s) or PR(s) and include a short summary here, too -->
@martinowren reported (Slack) that VIPPS uses space separators.

## How
<!-- How is your PR addressing the issue at hand? What are the implementation details?  -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

## Additional Info
<!-- Please include any relevant logs, error output, GraphiQL screenshots, etc -->

## Checklist:
<!-- We encourage you to complete this checklist to the best of your abilities. If you can't do everything, that's okay too.  -->
- [x] My code is tested to the best of my abilities.
- [x] My code follows the WordPress Coding Standards. <!-- Check code: `composer run check-cs`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/ -->
- [x] I have added unit tests to verify the code works as intended.
- [x] I included the relevant changes in CHANGELOG.md
