### PR TITLE
dev: use WooGraphQL 0.18.2 for `LoginPayload` fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to a modified version of [Semantic Versioning](./README
 
 - fix: Apply the `determine_current_user` filter before the plugin is initialized. H/t @kidunot89 for reporting.
 - dev: Refactor autoload handling to `WPGraphQL\Login\Autoloader` class. Note: this does *not* remove the `vendor/` or `vendor-prefixed/` directories from the repository.
+- dev: Remove local registration of `LoginPayload.customer` for WooGraphQL 0.18.2+. Props @kidunot89.
+- dev: Deprecate `LoginPayload.wooSessionToken` in favor of `loginPayload.sessionToken` (added in WooGraphQL 0.18.2+).
 - chore: Update Composer dependencies.
 - chore: Update WPGraphQL Coding Standards to v2.0.0-beta and lint.
 

--- a/src/Auth/Auth.php
+++ b/src/Auth/Auth.php
@@ -91,7 +91,7 @@ class Auth {
 			'refreshToken'           => TokenManager::get_refresh_token( $user ),
 			'refreshTokenExpiration' => User::get_refresh_token_expiration( $user->ID ),
 			'user'                   => $user,
-			'id'                     => $user->ID
+			'id'                     => $user->ID,
 		];
 
 		/**

--- a/src/Auth/Auth.php
+++ b/src/Auth/Auth.php
@@ -91,6 +91,7 @@ class Auth {
 			'refreshToken'           => TokenManager::get_refresh_token( $user ),
 			'refreshTokenExpiration' => User::get_refresh_token_expiration( $user->ID ),
 			'user'                   => $user,
+			'id'                     => $user->ID
 		];
 
 		/**

--- a/src/WoocommerceSchemaFilters.php
+++ b/src/WoocommerceSchemaFilters.php
@@ -68,40 +68,5 @@ class WoocommerceSchemaFilters implements Registrable {
 				},
 			]
 		);
-
-		// Register the customer and session token to the Login payloads.
-		register_graphql_fields(
-			'LoginPayload',
-			[
-				'customer'        => [
-					'type'        => 'Customer',
-					'description' => __( 'The customer object for the logged in user', 'wp-graphql-headless-login' ),
-					'resolve'     => static function ( $payload ) {
-						$user_id = isset( $payload['user']->ID ) ? $payload['user']->ID : null;
-
-						if ( ! $user_id ) {
-							return null;
-						}
-
-						return new \WPGraphQL\WooCommerce\Model\Customer( $user_id );
-					},
-				],
-				'wooSessionToken' => [
-					'type'        => 'String',
-					'description' => __( 'A JWT token used to identify the current WooCommerce session', 'wp-graphql-headless-login' ),
-					'resolve'     => static function () {
-						if ( ! function_exists( 'WC' ) ) {
-							return null;
-						}
-
-						/** @var \WPGraphQL\WooCommerce\Utils\QL_Session_Handler $session */
-						$session = \WC()->session;
-
-						/** \WooCommerce::$session */
-						return apply_filters( 'graphql_customer_session_token', $session->build_token() ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound
-					},
-				],
-			]
-		);
 	}
 }

--- a/src/WoocommerceSchemaFilters.php
+++ b/src/WoocommerceSchemaFilters.php
@@ -68,5 +68,57 @@ class WoocommerceSchemaFilters implements Registrable {
 				},
 			]
 		);
+
+		/**
+		 * In versions prior to WPGraphQL for WooCommerce v0.18.2, customer needs to be added to the LoginPayload type manually.
+		 *
+		 * @todo Remove this check when the minimum version of WPGraphQL for WooCommerce is > v0.18.2.
+		 */
+		if ( ! defined( 'WPGRAPHQL_WOOCOMMERCE_VERSION' ) || version_compare( WPGRAPHQL_WOOCOMMERCE_VERSION, '0.18.2', '<' ) ) {
+			// Register the customer and session token to the Login payloads.
+			register_graphql_field(
+				'LoginPayload',
+				'customer',
+				[
+					'type'        => 'Customer',
+					'description' => __( 'The customer object for the logged in user', 'wp-graphql-headless-login' ),
+					'resolve'     => static function ( $payload ) {
+						$user_id = isset( $payload['user']->ID ) ? $payload['user']->ID : null;
+
+						if ( ! $user_id ) {
+							return null;
+						}
+
+						return new \WPGraphQL\WooCommerce\Model\Customer( $user_id );
+					},
+				]
+			);
+		}
+
+		/**
+		 * In Woocommerce 0.18.2+ the session token is registered to the `LoginPayload` as `sessionToken`.
+		 *
+		 * @todo Remove this check when the minimum version of WPGraphQL for WooCommerce is > v0.18.2.
+		 */
+		register_graphql_field(
+			'LoginPayload',
+			'wooSessionToken',
+			[
+				'type'              => 'String',
+				'description'       => __( 'A JWT token used to identify the current WooCommerce session', 'wp-graphql-headless-login' ),
+				'deprecationReason' => __( 'Use `sessionToken` instead (available in WPGraphQL for WooCommerce v0.18.2+)', 'wp-graphql-headless-login' ),
+				'resolve'           => static function () {
+					if ( ! function_exists( 'WC' ) ) {
+						return null;
+					}
+
+					/** @var \WPGraphQL\WooCommerce\Utils\QL_Session_Handler $session */
+					$session = \WC()->session;
+
+					/** \WooCommerce::$session */
+					return apply_filters( 'graphql_customer_session_token', $session->build_token() ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound
+				},
+			],
+		);
 	}
 }


### PR DESCRIPTION
<!--
Thanks for taking the time to submit a Pull Request.
-->

## What
<!-- In a few words, what does this PR actually change -->
This PR defers the registration of `LoginPayload.customer` to WooGraphQL in v0.18.2+ (tba) which has added explicit support for this plugin.
Similarly, `LoginPayload.wooSessionToken` has been deprecated in favor of the `sessionToken` that WooGraphQL creates (and adds in v0.18.2+)

## Why
<!-- Why is this PR necessary? Please any existing previous issue(s) or PR(s) and include a short summary here, too -->
Ecosystem interoperability.

## How
<!-- How is your PR addressing the issue at hand? What are the implementation details?  -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

## Additional Info
<!-- Please include any relevant logs, error output, GraphiQL screenshots, etc -->

## Checklist:
<!-- We encourage you to complete this checklist to the best of your abilities. If you can't do everything, that's okay too.  -->
- [x] My code is tested to the best of my abilities.
- [x] My code follows the WordPress Coding Standards. <!-- Check code: `composer run check-cs`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/ -->
- [x] I have added unit tests to verify the code works as intended.
- [x] I included the relevant changes in CHANGELOG.md
