### PR TITLE
fix: apply 'determine_current_user' filter before plugin is initialized

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to a modified version of [Semantic Versioning](./README
 
 ## Unreleased
 
+- fix: Apply the `determine_current_user` filter before the plugin is initialized. H/t @kidunot89 for reporting.
 - chore: Update Composer dependencies.
 - chore: Update WPGraphQL Coding Standards to v2.0.0-beta and lint.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to a modified version of [Semantic Versioning](./README
 ## Unreleased
 
 - fix: Apply the `determine_current_user` filter before the plugin is initialized. H/t @kidunot89 for reporting.
+- dev: Refactor autoload handling to `WPGraphQL\Login\Autoloader` class. Note: this does *not* remove the `vendor/` or `vendor-prefixed/` directories from the repository.
 - chore: Update Composer dependencies.
 - chore: Update WPGraphQL Coding Standards to v2.0.0-beta and lint.
 

--- a/bin/_lib.sh
+++ b/bin/_lib.sh
@@ -154,7 +154,6 @@ post_setup() {
 	wp rewrite structure '/%year%/%monthnum%/%postname%/'
 	wp rewrite flush --allow-root
 
-	wp config set GRAPHQL_LOGIN_JWT_SECRET_KEY 'mysecretkey' --allow-root
 	wp config set WP_DEBUG true --raw --allow-root
 	wp config set WP_DEBUG_LOG true --raw --allow-root
 	wp config set GRAPHQL_DEBUG true --raw --allow-root

--- a/phpstan/constants.php
+++ b/phpstan/constants.php
@@ -5,7 +5,7 @@
  * @package WPGraphQL/Login
  */
 
-define( 'WPGRAPHQL_LOGIN_AUTOLOAD', true );
+define( 'WPGRAPHQL_LOGIN_AUTOLOAD', false );
 define( 'WPGRAPHQL_LOGIN_PLUGIN_FILE', 'wp-graphql-headless-login.php' );
 define( 'WPGRAPHQL_LOGIN_VERSION', '0.1.3' );
 define( 'WPGRAPHQL_LOGIN_PLUGIN_DIR', '' );

--- a/src/Auth/ServerAuthentication.php
+++ b/src/Auth/ServerAuthentication.php
@@ -72,6 +72,7 @@ class ServerAuthentication implements Registrable {
 		// Validate the token.
 		try {
 			$token = TokenManager::validate_token();
+
 			// If the token is invalid, return the existing user.
 			if ( empty( $token ) || is_wp_error( $token ) ) {
 				return $user_id;

--- a/src/Auth/ServerAuthentication.php
+++ b/src/Auth/ServerAuthentication.php
@@ -1,0 +1,87 @@
+<?php
+/**
+ * Handles authentication on the WordPress server, even before our plugin is loaded.
+ *
+ * @package WPGraphQL\Login\Auth
+ * @since @todo
+ */
+
+namespace WPGraphQL\Login\Auth;
+
+use WPGraphQL\Login\Vendor\AxeWP\GraphQL\Interfaces\Registrable;
+
+/**
+ * Class - ServerAuthentication
+ */
+class ServerAuthentication implements Registrable {
+	/**
+	 * The singleton instance of this class.
+	 *
+	 * @var ?self
+	 */
+	private static $instance;
+
+	/**
+	 * Whether the determine_current_user filter is being run.
+	 *
+	 * This is used to avoid an infinite loop.
+	 *
+	 * @var bool
+	 */
+	private bool $is_determine_current_user_filter = false;
+
+	/**
+	 * Gets the singleton instance of this class, or creates it if it doesn't exist.
+	 */
+	public static function instance(): self {
+		if ( ! isset( self::$instance ) || ! ( is_a( self::$instance, self::class ) ) ) {
+			self::$instance = new self();
+		}
+
+		return self::$instance;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public static function init(): void {
+		if ( ! self::$instance ) {
+			self::$instance = self::instance();
+
+			// Filter how WordPress determines the current user.
+			add_filter( 'determine_current_user', [ self::$instance, 'determine_current_user' ], 99 );
+		}
+	}
+
+	/**
+	 * Filters the current user for the request.
+	 *
+	 * @param int|mixed $user_id The user ID.
+	 *
+	 * @return int|mixed The user ID.
+	 */
+	public function determine_current_user( $user_id ) {
+		// Bail if this is already being run.
+		if ( $this->is_determine_current_user_filter ) {
+			return $user_id;
+		}
+
+		// Set the flag to true.
+		$this->is_determine_current_user_filter = true;
+	
+		// Validate the token.
+		try {
+			$token = TokenManager::validate_token();
+			// If the token is invalid, return the existing user.
+			if ( empty( $token ) || is_wp_error( $token ) ) {
+				return $user_id;
+			}
+
+			// Get the user from the token.
+			return empty( $token->data->user->id ) ? $user_id : absint( $token->data->user->id );
+		} finally {
+			// Set the flag to false.
+			$this->is_determine_current_user_filter = false;
+		}
+	}
+}

--- a/src/Auth/TokenManager.php
+++ b/src/Auth/TokenManager.php
@@ -434,7 +434,9 @@ class TokenManager {
 		/**
 		 * If there's no secret key, throw an error as there needs to be a secret key for Auth to work properly
 		 */
-		if ( empty( self::get_secret_key() ) ) {
+		$secret_key = self::get_secret_key();
+
+		if ( empty( $secret_key ) ) {
 			self::set_status( 403 );
 			return new WP_Error( 'invalid-secret-key', __( 'The JWT secret key is not set.', 'wp-graphql-headless-login' ) );
 		}
@@ -443,7 +445,7 @@ class TokenManager {
 		JWT::$leeway = 60;
 
 		try {
-			$token = empty( $token ) ? null : JWT::decode( sanitize_text_field( $token ), new Key( self::get_secret_key(), 'HS256' ) );
+			$token = empty( $token ) ? null : JWT::decode( sanitize_text_field( $token ), new Key( $secret_key, 'HS256' ) );
 		} catch ( \Throwable $exception ) {
 			/** @var \Exception $exception */
 			$token = new WP_Error( 'invalid-secret-key', $exception->getMessage() );

--- a/src/Autoloader.php
+++ b/src/Autoloader.php
@@ -18,8 +18,9 @@ class Autoloader {
 	 * @return false|mixed Whether the autoloader was loaded.
 	 */
 	public static function autoload() {
+		// If we're not *supposed* to autoload anything, then return true.
 		if ( defined( 'WPGRAPHQL_LOGIN_AUTOLOAD' ) && false === WPGRAPHQL_LOGIN_AUTOLOAD ) {
-			return false;
+			return true;
 		}
 
 		$autoloader = dirname( __DIR__ ) . '/vendor/autoload.php';

--- a/src/Autoloader.php
+++ b/src/Autoloader.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * Includes the composer Autoloader used for packages and classes in the src/ directory.
+ *
+ * @package WPGraphQL\Login
+ * @since @todo
+ */
+
+namespace WPGraphQL\Login;
+
+/**
+ * Class - Autoloader
+ */
+class Autoloader {
+	/**
+	 * Attempts to load the autoloader, if it exists.
+	 *
+	 * @return false|mixed Whether the autoloader was loaded.
+	 */
+	public static function autoload() {
+		if ( defined( 'WPGRAPHQL_LOGIN_AUTOLOAD' ) && false === WPGRAPHQL_LOGIN_AUTOLOAD ) {
+			return false;
+		}
+
+		$autoloader = dirname( __DIR__ ) . '/vendor/autoload.php';
+
+		if ( ! is_readable( $autoloader ) ) {
+			self::missing_autoloader_notice();
+			return false;
+		}
+
+		$loaded = require_once $autoloader; // phpcs:ignore WordPressVIPMinimum.Files.IncludingFile.UsingVariable
+
+		if ( ! $loaded ) {
+			return false;
+		}
+
+		return $loaded;
+	}
+
+	/**
+	 * Displays a notice if the autoloader is missing.
+	 */
+	protected static function missing_autoloader_notice(): void {
+		if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+			error_log( // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+				esc_html__( 'Headless Login for WPGraphQL: The Composer autoloader was not found. If you installed the plugin from the GitHub source, make sure to run `composer install`.', 'wp-graphql-headless-login' )
+			);
+		}
+
+		add_action(
+			'admin_notices',
+			static function () {
+				?>
+				<div class="error notice">
+					<p>
+						<?php
+							esc_html__( 'Headless Login for WPGraphQL: The Composer autoloader was not found. If you installed the plugin from the GitHub source, make sure to run `composer install`.', 'wp-graphql-headless-login' )
+						?>
+					</p>
+				</div>
+				<?php
+			}
+		);
+	}
+}

--- a/src/CoreSchemaFilters.php
+++ b/src/CoreSchemaFilters.php
@@ -24,9 +24,6 @@ class CoreSchemaFilters implements Registrable {
 		// Prefix the GraphQL type names.
 		add_filter( 'graphql_login_type_prefix', [ self::class, 'get_type_prefix' ] );
 
-		// Filter how WordPress determines the current user.
-		add_filter( 'determine_current_user', [ self::class, 'determine_current_user' ], 99 );
-
 		// Extend the User model to hold authentication data.
 		add_filter( 'graphql_model_prepare_fields', [ User::class, 'get_fields' ], 10, 3 );
 
@@ -67,25 +64,5 @@ class CoreSchemaFilters implements Registrable {
 		}
 
 		return $token;
-	}
-
-	/**
-	 * Filters the current user for the request.
-	 *
-	 * @param int $user_id The user ID.
-	 */
-	public static function determine_current_user( int $user_id ): int {
-		// Validate the token.
-		$token = TokenManager::validate_token();
-
-		// If the token is invalid, return the existing user.
-		if ( empty( $token ) || is_wp_error( $token ) ) {
-			return $user_id;
-		}
-
-		// Get the user from the token.
-		$user_id = empty( $token->data->user->id ) ? $user_id : $token->data->user->id;
-
-		return absint( $user_id );
 	}
 }

--- a/src/Main.php
+++ b/src/Main.php
@@ -38,7 +38,6 @@ if ( ! class_exists( \WPGraphQL\Login\Main::class ) ) :
 				}
 
 				self::$instance = new self();
-				self::$instance->includes();
 				self::$instance->setup();
 				// @codeCoverageIgnoreEnd
 			}
@@ -51,19 +50,6 @@ if ( ! class_exists( \WPGraphQL\Login\Main::class ) ) :
 			do_action( 'graphql_login_init', self::$instance );
 
 			return self::$instance;
-		}
-
-		/**
-		 * Includes the required files with Composer's autoload.
-		 *
-		 * @codeCoverageIgnore
-		 */
-		private function includes(): void {
-			if ( defined( 'WPGRAPHQL_LOGIN_AUTOLOAD' ) && false !== WPGRAPHQL_LOGIN_AUTOLOAD && defined( 'WPGRAPHQL_LOGIN_PLUGIN_DIR' ) ) {
-				require_once WPGRAPHQL_LOGIN_PLUGIN_DIR . 'vendor/autoload.php';
-			}
-
-			require_once WPGRAPHQL_LOGIN_PLUGIN_DIR . 'vendor/autoload.php';
 		}
 
 		/**

--- a/tests/wpunit/CoreSchemaFiltersTest.php
+++ b/tests/wpunit/CoreSchemaFiltersTest.php
@@ -75,31 +75,4 @@ class CoreSchemaFiltersTest extends \Codeception\TestCase\WPTestCase {
 
 		$this->assertEquals( $expected, $actual );
 	}
-
-	public function testDetermineCurrentUser(): void {
-		$user_id = $this->factory()->user->create();
-
-		// Test without token.
-		$actual = CoreSchemaFilters::determine_current_user( $this->admin );
-
-		$this->assertEquals( $this->admin, $actual );
-
-		// Test with valid secret.
-		$tokens = $this->tester->generate_user_tokens( $user_id );
-
-		$_SERVER['HTTP_AUTHORIZATION'] = 'Bearer ' . $tokens['auth_token'];
-
-		$actual = CoreSchemaFilters::determine_current_user( $this->admin );
-
-		$this->assertEquals( $user_id, $actual );
-
-		// Test user returns same user.
-		$actual = CoreSchemaFilters::determine_current_user( $user_id );
-
-		$this->assertEquals( $user_id, $actual );
-
-		// cleanup.
-		unset( $_SERVER['HTTP_AUTHORIZATION'] );
-		wp_delete_user( $user_id );
-	}
 }

--- a/tests/wpunit/ServerAuthenticationTest.php
+++ b/tests/wpunit/ServerAuthenticationTest.php
@@ -1,0 +1,61 @@
+<?php
+
+use WPGraphQL\Login\Auth\ServerAuthentication;
+
+/**
+ * Tests ServerAuthentication.
+ */
+class ServerAuthenticationTest extends \Codeception\TestCase\WPTestCase {
+
+	/**
+	 * @var \WpunitTester
+	 */
+	protected $tester;
+	public $admin;
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->admin = $this->factory()->user->create(
+			[
+				'role' => 'administrator',
+			]
+		);
+	}
+
+	/**
+	 * Tests determine_current_user.
+	 *
+	 * @covers \WPGraphQL\Login\Auth\ServerAuthentication
+	 */
+	public function testDetermineCurrentUser(): void {
+		$instance = ServerAuthentication::instance();
+		$user_id = $this->factory()->user->create();
+
+		// Test without token.
+		$actual = $instance->determine_current_user( $this->admin );
+
+		$this->assertEquals( $this->admin, $actual );
+
+		// Test with valid secret.
+		$tokens = $this->tester->generate_user_tokens( $user_id );
+
+		$_SERVER['HTTP_AUTHORIZATION'] = 'Bearer ' . $tokens['auth_token'];
+
+		$actual = $instance->determine_current_user( $this->admin );
+
+		$this->assertEquals( $user_id, $actual );
+
+		// Test user returns same user.
+		$actual = $instance->determine_current_user( $user_id );
+
+		$this->assertEquals( $user_id, $actual );
+
+		// cleanup.
+		unset( $_SERVER['HTTP_AUTHORIZATION'] );
+		wp_delete_user( $user_id );
+	}
+}

--- a/vendor/composer/autoload_classmap.php
+++ b/vendor/composer/autoload_classmap.php
@@ -204,6 +204,7 @@ return array(
     'WPGraphQL\\Login\\Auth\\ServerAuthentication' => $baseDir . '/src/Auth/ServerAuthentication.php',
     'WPGraphQL\\Login\\Auth\\TokenManager' => $baseDir . '/src/Auth/TokenManager.php',
     'WPGraphQL\\Login\\Auth\\User' => $baseDir . '/src/Auth/User.php',
+    'WPGraphQL\\Login\\Autoloader' => $baseDir . '/src/Autoloader.php',
     'WPGraphQL\\Login\\CoreSchemaFilters' => $baseDir . '/src/CoreSchemaFilters.php',
     'WPGraphQL\\Login\\Fields\\RootQuery' => $baseDir . '/src/Fields/RootQuery.php',
     'WPGraphQL\\Login\\Main' => $baseDir . '/src/Main.php',

--- a/vendor/composer/autoload_classmap.php
+++ b/vendor/composer/autoload_classmap.php
@@ -201,6 +201,7 @@ return array(
     'WPGraphQL\\Login\\Auth\\ProviderConfig\\SiteToken' => $baseDir . '/src/Auth/ProviderConfig/SiteToken.php',
     'WPGraphQL\\Login\\Auth\\ProviderRegistry' => $baseDir . '/src/Auth/ProviderRegistry.php',
     'WPGraphQL\\Login\\Auth\\Request' => $baseDir . '/src/Auth/Request.php',
+    'WPGraphQL\\Login\\Auth\\ServerAuthentication' => $baseDir . '/src/Auth/ServerAuthentication.php',
     'WPGraphQL\\Login\\Auth\\TokenManager' => $baseDir . '/src/Auth/TokenManager.php',
     'WPGraphQL\\Login\\Auth\\User' => $baseDir . '/src/Auth/User.php',
     'WPGraphQL\\Login\\CoreSchemaFilters' => $baseDir . '/src/CoreSchemaFilters.php',

--- a/vendor/composer/autoload_static.php
+++ b/vendor/composer/autoload_static.php
@@ -285,6 +285,7 @@ class ComposerStaticInite3dd5adcad35e0c0a990ad87f09c52a0
         'WPGraphQL\\Login\\Auth\\ProviderConfig\\SiteToken' => __DIR__ . '/../..' . '/src/Auth/ProviderConfig/SiteToken.php',
         'WPGraphQL\\Login\\Auth\\ProviderRegistry' => __DIR__ . '/../..' . '/src/Auth/ProviderRegistry.php',
         'WPGraphQL\\Login\\Auth\\Request' => __DIR__ . '/../..' . '/src/Auth/Request.php',
+        'WPGraphQL\\Login\\Auth\\ServerAuthentication' => __DIR__ . '/../..' . '/src/Auth/ServerAuthentication.php',
         'WPGraphQL\\Login\\Auth\\TokenManager' => __DIR__ . '/../..' . '/src/Auth/TokenManager.php',
         'WPGraphQL\\Login\\Auth\\User' => __DIR__ . '/../..' . '/src/Auth/User.php',
         'WPGraphQL\\Login\\CoreSchemaFilters' => __DIR__ . '/../..' . '/src/CoreSchemaFilters.php',

--- a/vendor/composer/autoload_static.php
+++ b/vendor/composer/autoload_static.php
@@ -288,6 +288,7 @@ class ComposerStaticInite3dd5adcad35e0c0a990ad87f09c52a0
         'WPGraphQL\\Login\\Auth\\ServerAuthentication' => __DIR__ . '/../..' . '/src/Auth/ServerAuthentication.php',
         'WPGraphQL\\Login\\Auth\\TokenManager' => __DIR__ . '/../..' . '/src/Auth/TokenManager.php',
         'WPGraphQL\\Login\\Auth\\User' => __DIR__ . '/../..' . '/src/Auth/User.php',
+        'WPGraphQL\\Login\\Autoloader' => __DIR__ . '/../..' . '/src/Autoloader.php',
         'WPGraphQL\\Login\\CoreSchemaFilters' => __DIR__ . '/../..' . '/src/CoreSchemaFilters.php',
         'WPGraphQL\\Login\\Fields\\RootQuery' => __DIR__ . '/../..' . '/src/Fields/RootQuery.php',
         'WPGraphQL\\Login\\Main' => __DIR__ . '/../..' . '/src/Main.php',

--- a/vendor/composer/installed.php
+++ b/vendor/composer/installed.php
@@ -3,7 +3,7 @@
         'name' => 'axepress/wp-graphql-headless-login',
         'pretty_version' => 'dev-develop',
         'version' => 'dev-develop',
-        'reference' => '021b1a31684fa7770d0e244dfdd27c4ed2597b88',
+        'reference' => '91760c7c9930b6f8094c31aa8e50b51fce0c505b',
         'type' => 'wordpress-plugin',
         'install_path' => __DIR__ . '/../../',
         'aliases' => array(),
@@ -13,7 +13,7 @@
         'axepress/wp-graphql-headless-login' => array(
             'pretty_version' => 'dev-develop',
             'version' => 'dev-develop',
-            'reference' => '021b1a31684fa7770d0e244dfdd27c4ed2597b88',
+            'reference' => '91760c7c9930b6f8094c31aa8e50b51fce0c505b',
             'type' => 'wordpress-plugin',
             'install_path' => __DIR__ . '/../../',
             'aliases' => array(),

--- a/vendor/composer/installed.php
+++ b/vendor/composer/installed.php
@@ -3,7 +3,7 @@
         'name' => 'axepress/wp-graphql-headless-login',
         'pretty_version' => 'dev-develop',
         'version' => 'dev-develop',
-        'reference' => '4357b9bd9a552a16bb5cf5c6226e92830be041ac',
+        'reference' => '021b1a31684fa7770d0e244dfdd27c4ed2597b88',
         'type' => 'wordpress-plugin',
         'install_path' => __DIR__ . '/../../',
         'aliases' => array(),
@@ -13,7 +13,7 @@
         'axepress/wp-graphql-headless-login' => array(
             'pretty_version' => 'dev-develop',
             'version' => 'dev-develop',
-            'reference' => '4357b9bd9a552a16bb5cf5c6226e92830be041ac',
+            'reference' => '021b1a31684fa7770d0e244dfdd27c4ed2597b88',
             'type' => 'wordpress-plugin',
             'install_path' => __DIR__ . '/../../',
             'aliases' => array(),

--- a/wp-graphql-headless-login.php
+++ b/wp-graphql-headless-login.php
@@ -29,6 +29,12 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
+// Load the autoloader.
+require_once __DIR__ . '/src/Autoloader.php';
+if ( ! \WPGraphQL\Login\Autoloader::autoload() ) {
+	return;
+}
+
 // If the codeception remote coverage file exists, require it.
 // This file should only exist locally or when CI bootstraps the environment for testing.
 if ( file_exists( __DIR__ . '/c3.php' ) ) {
@@ -46,6 +52,7 @@ if ( file_exists( __DIR__ . '/deactivation.php' ) ) {
 	require_once __DIR__ . '/deactivation.php';
 	register_activation_hook( __FILE__, 'graphql_login_deactivation_callback' );
 }
+
 
 if ( ! function_exists( 'graphql_login_constants' ) ) {
 	/**

--- a/wp-graphql-headless-login.php
+++ b/wp-graphql-headless-login.php
@@ -194,3 +194,8 @@ if ( ! function_exists( 'graphql_login_init' ) ) {
 }
 // Initialize the plugin.
 add_action( 'graphql_init', 'graphql_login_init' );
+
+// Some plugins may rely on authentication even before our plugin is initialized.
+if ( class_exists( 'WPGraphQL\Login\Auth\ServerAuthentication' ) ) {
+	\WPGraphQL\Login\Auth\ServerAuthentication::init();
+}


### PR DESCRIPTION
<!--
Thanks for taking the time to submit a Pull Request.
-->

## What
<!-- In a few words, what does this PR actually change -->
This PR fixes an issue where `determine_current_user` was only being applied after the rest of the plugin is initialized (after 'graphql_init').

## Why
<!-- Why is this PR necessary? Please any existing previous issue(s) or PR(s) and include a short summary here, too -->
External plugins need to check the user's validity, sometimes even before `plugins_loaded`. E.g. https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce/includes/class-wc-session-handler.php#L104-L110

h/t @kidunot89 

## How
<!-- How is your PR addressing the issue at hand? What are the implementation details?  -->

The `determine_current_user` filter has been moved from `CoreSchemaFilters` to a new `Auth\ServerAuthentication` class, which is hooked separately from the rest of the plugin initialization.

Additionally, the type requirements of the `$user_id` param have been loosened to allow for better compatibility with external plugins who arent adhering to WP's types, and an instance property has been added to prevent recursion.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

## Additional Info
<!-- Please include any relevant logs, error output, GraphiQL screenshots, etc -->

## Checklist:
<!-- We encourage you to complete this checklist to the best of your abilities. If you can't do everything, that's okay too.  -->
- [x] My code is tested to the best of my abilities.
- [x] My code follows the WordPress Coding Standards. <!-- Check code: `composer run check-cs`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/ -->
- [x] I have added unit tests to verify the code works as intended.
- [x] I included the relevant changes in CHANGELOG.md
