### PR TITLE
fix: Avoid strict-typing `League\OAuth2\Client\Provider\AbstractProvider` to the `\WPGraphQL\Login\Vendor` namespace.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to a modified version of [Semantic Versioning](./README
 
 ## Unreleased
 
+- fix: Avoid strict-typing `League\OAuth2\Client\Provider\AbstractProvider` to the `\WPGraphQL\Login\Vendor` namespace. H/t @pat-flew .
 - chore!: Bump minimum supported WordPress version to 6.0.
 - chore!: Bump minimum supported WPGraphQL version to 1.14.0.
 - chore: Update `WPGraphQL Coding Standards` to latest version and lint.

--- a/src/Auth/ProviderConfig/OAuth2/OAuth2Config.php
+++ b/src/Auth/ProviderConfig/OAuth2/OAuth2Config.php
@@ -14,7 +14,6 @@ use GraphQL\Error\UserError;
 use WPGraphQL\Login\Auth\ProviderConfig\ProviderConfig;
 use WPGraphQL\Login\Auth\User;
 use WPGraphQL\Login\Utils\Utils;
-use WPGraphQL\Login\Vendor\League\OAuth2\Client\Provider\AbstractProvider;
 use WP_Error;
 
 /**
@@ -40,7 +39,7 @@ abstract class OAuth2Config extends ProviderConfig {
 	 *
 	 * @var \WPGraphQL\Login\Vendor\League\OAuth2\Client\Provider\AbstractProvider
 	 */
-	protected AbstractProvider $provider;
+	protected $provider;
 
 	/**
 	 * The authorization URL.
@@ -52,17 +51,18 @@ abstract class OAuth2Config extends ProviderConfig {
 	/**
 	 * {@inheritDoc}
 	 *
-	 * @param class-string $provider_class The OAuth2 provider class.
+	 * @param string $provider_class The OAuth2 provider class.
 	 *
 	 * @throws \InvalidArgumentException If the provider class is not a subclass of AbstractProvider.
 	 */
 	public function __construct( string $provider_class ) {
 		$this->client_options = $this->prepare_client_options();
 
-		if ( ! is_a( $provider_class, AbstractProvider::class, true ) ) {
+		if ( ! str_ends_with( $provider_class, 'League\OAuth2\Client\Provider\AbstractProvider' ) ) { // This way we can use namespaced/non-namespaced classes.
 			throw new \InvalidArgumentException( 'The provider class must extend AbstractProvider.' );
 		}
 
+		/** @var class-string<\WPGraphQL\Login\Vendor\League\OAuth2\Client\Provider\AbstractProvider> $provider_class */
 		$this->provider = new $provider_class( $this->client_options );
 
 		$this->authorization_url = $this->prepare_authorization_url( $this->client_options );

--- a/src/Auth/ProviderConfig/OAuth2/OAuth2Config.php
+++ b/src/Auth/ProviderConfig/OAuth2/OAuth2Config.php
@@ -60,7 +60,13 @@ abstract class OAuth2Config extends ProviderConfig {
 		$this->client_options = $this->prepare_client_options();
 
 		if ( ! is_a( $provider_class, AbstractProvider::class, true ) && ! is_a( $provider_class, 'League\OAuth2\Client\Provider\AbstractProvider', true ) ) { // Check for the prefixed and unprefixed class names.
-			throw new \InvalidArgumentException( 'The provider class must extend AbstractProvider. %s does not' );
+			throw new \InvalidArgumentException(
+				sprintf(
+					// translators: the provider class name.
+					esc_html__( 'The provider class must extend AbstractProvider. %s does not', 'wp-graphql-headless-login' ),
+					esc_html( $provider_class )
+				)
+			);
 		}
 
 		/** @var class-string<\WPGraphQL\Login\Vendor\League\OAuth2\Client\Provider\AbstractProvider> $provider_class */

--- a/src/Auth/ProviderConfig/OAuth2/OAuth2Config.php
+++ b/src/Auth/ProviderConfig/OAuth2/OAuth2Config.php
@@ -14,6 +14,7 @@ use GraphQL\Error\UserError;
 use WPGraphQL\Login\Auth\ProviderConfig\ProviderConfig;
 use WPGraphQL\Login\Auth\User;
 use WPGraphQL\Login\Utils\Utils;
+use WPGraphQL\Login\Vendor\League\OAuth2\Client\Provider\AbstractProvider;
 use WP_Error;
 
 /**
@@ -58,8 +59,8 @@ abstract class OAuth2Config extends ProviderConfig {
 	public function __construct( string $provider_class ) {
 		$this->client_options = $this->prepare_client_options();
 
-		if ( ! str_ends_with( $provider_class, 'League\OAuth2\Client\Provider\AbstractProvider' ) ) { // This way we can use namespaced/non-namespaced classes.
-			throw new \InvalidArgumentException( 'The provider class must extend AbstractProvider.' );
+		if ( ! is_a( $provider_class, AbstractProvider::class, true ) && ! is_a( $provider_class, 'League\OAuth2\Client\Provider\AbstractProvider', true ) ) { // Check for the prefixed and unprefixed class names.
+			throw new \InvalidArgumentException( 'The provider class must extend AbstractProvider. %s does not' );
 		}
 
 		/** @var class-string<\WPGraphQL\Login\Vendor\League\OAuth2\Client\Provider\AbstractProvider> $provider_class */


### PR DESCRIPTION
<!--
Thanks for taking the time to submit a Pull Request.
-->

## What
<!-- In a few words, what does this PR actually change -->

This PR removes the strict-typing in `OAuth2Config` for `\WPGraphQL\Login\Vendor\League\OAuth2\Client\Provider\AbstractProvider`. PHPDoc hints are used instead.


## Why
<!-- Why is this PR necessary? Please any existing previous issue(s) or PR(s) and include a short summary here, too -->
Closes #106 

## How
<!-- How is your PR addressing the issue at hand? What are the implementation details?  -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

## Additional Info
<!-- Please include any relevant logs, error output, GraphiQL screenshots, etc -->

## Checklist:
<!-- We encourage you to complete this checklist to the best of your abilities. If you can't do everything, that's okay too.  -->
- [x] My code is tested to the best of my abilities.
- [x] My code follows the WordPress Coding Standards. <!-- Check code: `composer run check-cs`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/ -->
- [x] I have added unit tests to verify the code works as intended.
- [x] I included the relevant changes in CHANGELOG.md
