### PR TITLE
feat: expose `refreshToken.authTokenExpiration`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to a modified version of [Semantic Versioning](./README
 
 ## Unreleased
 
+- feat: Add the `authTokenExpiration` field to the `refreshToken` mutation response. H/t @richardaubin.
+
 ## [0.2.0] - 2024-02-04
 
 This _major_ release bumps the minimum supported WordPress version to 6.0, and the minimum supported WPGraphQL version to 1.14.0. It also fixes a bug when extending the `OAuth2Config` class`.

--- a/docs/reference/mutations.md
+++ b/docs/reference/mutations.md
@@ -102,11 +102,11 @@ mutation refreshToken(
 ) {
   refreshToken( input: {refreshToken: $token} ) {
     authToken # The new auth token for the user.
+    authTokenExpiration # The expiration time of the new auth token.
     success
   }
 }
 ```
-
 
 ## Manually link the WordPress user to a Provider's Resource Owner
 

--- a/tests/wpunit/RefreshTokenMutationTest.php
+++ b/tests/wpunit/RefreshTokenMutationTest.php
@@ -63,6 +63,7 @@ class RefreshTokenMutationTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCa
 			mutation RefreshToken( $refreshToken: String! ) {
 				refreshToken( input: { refreshToken: $refreshToken } ) {
 					authToken
+					authTokenExpiration
 					success
 				}
 			}
@@ -82,6 +83,7 @@ class RefreshTokenMutationTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCa
 		$this->assertArrayNotHasKey( 'errors', $actual );
 		$this->assertFalse( $actual['data']['refreshToken']['success'] );
 		$this->assertNull( $actual['data']['refreshToken']['authToken'] );
+		$this->assertNull( $actual['data']['refreshToken']['authTokenExpiration'] );
 		$this->assertEquals( 'Wrong number of segments', $actual['extensions']['debug'][0]['message'] );
 	}
 
@@ -122,6 +124,7 @@ class RefreshTokenMutationTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCa
 		$this->assertArrayNotHasKey( 'errors', $actual );
 		$this->assertFalse( $actual['data']['refreshToken']['success'] );
 		$this->assertNull( $actual['data']['refreshToken']['authToken'] );
+		$this->assertNull( $actual['data']['refreshToken']['authTokenExpiration'] );
 		$this->assertEquals( 'Signature verification failed', $actual['extensions']['debug'][0]['message'] );
 
 		// Test different user as admin
@@ -141,6 +144,7 @@ class RefreshTokenMutationTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCa
 		$this->assertArrayNotHasKey( 'errors', $actual );
 		$this->assertFalse( $actual['data']['refreshToken']['success'] );
 		$this->assertNull( $actual['data']['refreshToken']['authToken'] );
+		$this->assertNull( $actual['data']['refreshToken']['authTokenExpiration'] );
 		$this->assertEquals( 'Signature verification failed', $actual['extensions']['debug'][0]['message'] );
 	}
 
@@ -157,7 +161,7 @@ class RefreshTokenMutationTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCa
 		$this->assertArrayNotHasKey( 'errors', $actual );
 		$this->assertFalse( $actual['data']['refreshToken']['success'] );
 		$this->assertNull( $actual['data']['refreshToken']['authToken'] );
-
+		$this->assertNull( $actual['data']['refreshToken']['authTokenExpiration'] );
 		$this->assertEquals( 'User secret not found in the token.', $actual['extensions']['debug'][0]['message'] );
 
 		// Test auth token as test user
@@ -168,7 +172,7 @@ class RefreshTokenMutationTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCa
 		$this->assertArrayNotHasKey( 'errors', $actual );
 		$this->assertFalse( $actual['data']['refreshToken']['success'] );
 		$this->assertNull( $actual['data']['refreshToken']['authToken'] );
-
+		$this->assertNull( $actual['data']['refreshToken']['authTokenExpiration'] );
 		$this->assertEquals( 'User secret not found in the token.', $actual['extensions']['debug'][0]['message'] );
 	}
 
@@ -190,6 +194,7 @@ class RefreshTokenMutationTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCa
 		$this->assertArrayNotHasKey( 'errors', $actual );
 		$this->assertFalse( $actual['data']['refreshToken']['success'] );
 		$this->assertNull( $actual['data']['refreshToken']['authToken'] );
+		$this->assertNull( $actual['data']['refreshToken']['authTokenExpiration'] );
 		$this->assertEquals( 'User secret is revoked.', $actual['extensions']['debug'][0]['message'] );
 	}
 
@@ -212,6 +217,7 @@ class RefreshTokenMutationTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCa
 		$this->assertArrayNotHasKey( 'errors', $actual );
 		$this->assertFalse( $actual['data']['refreshToken']['success'] );
 		$this->assertNull( $actual['data']['refreshToken']['authToken'] );
+		$this->assertNull( $actual['data']['refreshToken']['authTokenExpiration'] );
 		$this->assertEquals( 'User secret does not match.', $actual['extensions']['debug'][0]['message'] );
 
 		// Test as admin
@@ -222,6 +228,7 @@ class RefreshTokenMutationTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCa
 		$this->assertArrayNotHasKey( 'errors', $actual );
 		$this->assertFalse( $actual['data']['refreshToken']['success'] );
 		$this->assertNull( $actual['data']['refreshToken']['authToken'] );
+		$this->assertNull( $actual['data']['refreshToken']['authTokenExpiration'] );
 		$this->assertEquals( 'User secret does not match.', $actual['extensions']['debug'][0]['message'] );
 	}
 
@@ -237,7 +244,8 @@ class RefreshTokenMutationTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCa
 		$this->assertArrayNotHasKey( 'errors', $actual );
 		$this->assertTrue( $actual['data']['refreshToken']['success'] );
 		$this->assertNotNull( $actual['data']['refreshToken']['authToken'] );
+
+		$expected_expiration = User::get_auth_token_expiration( $this->test_user );
+		$this->assertEquals( $expected_expiration, $actual['data']['refreshToken']['authTokenExpiration'] );
 	}
-
-
 }


### PR DESCRIPTION
<!--
Thanks for taking the time to submit a Pull Request.
-->

## What
<!-- In a few words, what does this PR actually change -->

This PR adds the `authTokenExpiration` field to the `refreshToken` mutation payload.

## Why
<!-- Why is this PR necessary? Please any existing previous issue(s) or PR(s) and include a short summary here, too -->
API oversight, flagged by @richardaubin in [Slack](https://wp-graphql.slack.com/archives/C05BDQ376LA/p1707115150279189?thread_ts=1706550831.628589&cid=C05BDQ376LA)

## How
<!-- How is your PR addressing the issue at hand? What are the implementation details?  -->

## Testing Instructions
```graphql
mutation refreshToken(
  $token: String! # The user's refreshToken.
) {
  refreshToken( input: {refreshToken: $token} ) {
    authToken
    authTokenExpiration # 👈
    success
  }
}
```

## Additional Info
<!-- Please include any relevant logs, error output, GraphiQL screenshots, etc -->

## Checklist:
<!-- We encourage you to complete this checklist to the best of your abilities. If you can't do everything, that's okay too.  -->
- [x] My code is tested to the best of my abilities.
- [x] My code follows the WordPress Coding Standards. <!-- Check code: `composer run check-cs`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/ -->
- [x] I have added unit tests to verify the code works as intended.
- [x] I included the relevant changes in CHANGELOG.md
