### PR TITLE
chore: declare `strict_types`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to a modified version of [Semantic Versioning](./README
 
 - feat: Add the `authTokenExpiration` field to the `refreshToken` mutation response. H/t @richardaubin.
 - chore!: Add `WPGraphQL/RankMath` namespace to root-level files ( `activation.php`, `deactivation.php`, `wp-graphql-rank-math.php` ).
+- chore: Declare `strict_types` in all PHP files.
 - chore: Update Composer dev-deps and fix newly-surfaced PHPCS smells.
 - chore: Lock WPBrowser to v3.5.x to prevent conflicts with Codeception.
 - chore: Implement PHPStan strict rules and fix type errors.

--- a/access-functions.php
+++ b/access-functions.php
@@ -6,6 +6,8 @@
  * @since 0.0.1
  */
 
+declare( strict_types = 1 );
+
 use WPGraphQL\Login\Utils\Utils;
 
 if ( ! function_exists( 'graphql_login_get_setting' ) ) {

--- a/activation.php
+++ b/activation.php
@@ -6,6 +6,8 @@
  * @since 0.0.1
  */
 
+declare( strict_types = 1 );
+
 namespace WPGraphQL\Login;
 
 /**

--- a/deactivation.php
+++ b/deactivation.php
@@ -6,6 +6,8 @@
  * @since 0.0.1
  */
 
+declare( strict_types = 1 );
+
 namespace WPGraphQL\Login;
 
 	/**

--- a/src/Admin/Settings.php
+++ b/src/Admin/Settings.php
@@ -6,6 +6,8 @@
  * @since 0.0.1
  */
 
+declare( strict_types = 1 );
+
 namespace WPGraphQL\Login\Admin;
 
 use Error;

--- a/src/Admin/Settings/AccessControlSettings.php
+++ b/src/Admin/Settings/AccessControlSettings.php
@@ -6,6 +6,8 @@
  * @since 0.0.6
  */
 
+declare( strict_types = 1 );
+
 namespace WPGraphQL\Login\Admin\Settings;
 
 /**

--- a/src/Admin/Settings/PluginSettings.php
+++ b/src/Admin/Settings/PluginSettings.php
@@ -6,6 +6,8 @@
  * @since 0.0.6
  */
 
+declare( strict_types = 1 );
+
 namespace WPGraphQL\Login\Admin\Settings;
 
 /**

--- a/src/Admin/Settings/ProviderSettings.php
+++ b/src/Admin/Settings/ProviderSettings.php
@@ -6,6 +6,8 @@
  * @since 0.0.6
  */
 
+declare( strict_types = 1 );
+
 namespace WPGraphQL\Login\Admin\Settings;
 
 use WPGraphQL\Login\Auth\ProviderRegistry;

--- a/src/Admin/UserProfile.php
+++ b/src/Admin/UserProfile.php
@@ -6,6 +6,8 @@
  * @since 0.0.1
  */
 
+declare( strict_types = 1 );
+
 namespace WPGraphQL\Login\Admin;
 
 use WPGraphQL\Login\Auth\ProviderConfig\Password;

--- a/src/Auth/Auth.php
+++ b/src/Auth/Auth.php
@@ -6,6 +6,8 @@
  * @since 0.0.1
  */
 
+declare( strict_types = 1 );
+
 namespace WPGraphQL\Login\Auth;
 
 use GraphQL\Error\UserError;

--- a/src/Auth/Client.php
+++ b/src/Auth/Client.php
@@ -6,6 +6,8 @@
  * @since 0.0.1
  */
 
+declare( strict_types = 1 );
+
 namespace WPGraphQL\Login\Auth;
 
 use WPGraphQL\Login\Auth\ProviderConfig\ProviderConfig;

--- a/src/Auth/ProviderConfig/OAuth2/Facebook.php
+++ b/src/Auth/ProviderConfig/OAuth2/Facebook.php
@@ -6,6 +6,8 @@
  * @since 0.0.1
  */
 
+declare( strict_types = 1 );
+
 namespace WPGraphQL\Login\Auth\ProviderConfig\OAuth2;
 
 use WPGraphQL\Login\Vendor\League\OAuth2\Client\Provider\Facebook as FacebookProvider;

--- a/src/Auth/ProviderConfig/OAuth2/Generic.php
+++ b/src/Auth/ProviderConfig/OAuth2/Generic.php
@@ -6,6 +6,8 @@
  * @since 0.0.1
  */
 
+declare( strict_types = 1 );
+
 namespace WPGraphQL\Login\Auth\ProviderConfig\OAuth2;
 
 use WPGraphQL\Login\Vendor\League\OAuth2\Client\Provider\GenericProvider;

--- a/src/Auth/ProviderConfig/OAuth2/GitHub.php
+++ b/src/Auth/ProviderConfig/OAuth2/GitHub.php
@@ -6,6 +6,8 @@
  * @since 0.0.1
  */
 
+declare( strict_types = 1 );
+
 namespace WPGraphQL\Login\Auth\ProviderConfig\OAuth2;
 
 use WPGraphQL\Login\Vendor\League\OAuth2\Client\Provider\Github as GithubProvider;

--- a/src/Auth/ProviderConfig/OAuth2/Google.php
+++ b/src/Auth/ProviderConfig/OAuth2/Google.php
@@ -6,6 +6,8 @@
  * @since 0.0.1
  */
 
+declare( strict_types = 1 );
+
 namespace WPGraphQL\Login\Auth\ProviderConfig\OAuth2;
 
 use WPGraphQL\Login\Type\Enum\GoogleProviderPromptTypeEnum;

--- a/src/Auth/ProviderConfig/OAuth2/Instagram.php
+++ b/src/Auth/ProviderConfig/OAuth2/Instagram.php
@@ -6,6 +6,8 @@
  * @since 0.0.3
  */
 
+declare( strict_types = 1 );
+
 namespace WPGraphQL\Login\Auth\ProviderConfig\OAuth2;
 
 use WPGraphQL\Login\Vendor\League\OAuth2\Client\Provider\Instagram as InstagramProvider;

--- a/src/Auth/ProviderConfig/OAuth2/LinkedIn.php
+++ b/src/Auth/ProviderConfig/OAuth2/LinkedIn.php
@@ -6,6 +6,8 @@
  * @since 0.0.3
  */
 
+declare( strict_types = 1 );
+
 namespace WPGraphQL\Login\Auth\ProviderConfig\OAuth2;
 
 use WPGraphQL\Login\Vendor\League\OAuth2\Client\Provider\LinkedIn as LinkedInProvider;

--- a/src/Auth/ProviderConfig/OAuth2/OAuth2Config.php
+++ b/src/Auth/ProviderConfig/OAuth2/OAuth2Config.php
@@ -8,6 +8,8 @@
  * @since 0.0.1
  */
 
+declare( strict_types = 1 );
+
 namespace WPGraphQL\Login\Auth\ProviderConfig\OAuth2;
 
 use GraphQL\Error\UserError;

--- a/src/Auth/ProviderConfig/Password.php
+++ b/src/Auth/ProviderConfig/Password.php
@@ -6,6 +6,8 @@
  * @since 0.0.6
  */
 
+declare( strict_types = 1 );
+
 namespace WPGraphQL\Login\Auth\ProviderConfig;
 
 use GraphQL\Error\UserError;

--- a/src/Auth/ProviderConfig/ProviderConfig.php
+++ b/src/Auth/ProviderConfig/ProviderConfig.php
@@ -8,6 +8,8 @@
  * @since 0.0.1
  */
 
+declare( strict_types = 1 );
+
 namespace WPGraphQL\Login\Auth\ProviderConfig;
 
 /**

--- a/src/Auth/ProviderConfig/ProviderConfigStaticTrait.php
+++ b/src/Auth/ProviderConfig/ProviderConfigStaticTrait.php
@@ -6,6 +6,8 @@
  * @since 0.0.1
  */
 
+declare( strict_types = 1 );
+
 namespace WPGraphQL\Login\Auth\ProviderConfig;
 
 use WPGraphQL\Login\Utils\Utils;

--- a/src/Auth/ProviderConfig/SiteToken.php
+++ b/src/Auth/ProviderConfig/SiteToken.php
@@ -6,6 +6,8 @@
  * @since 0.0.6
  */
 
+declare( strict_types = 1 );
+
 namespace WPGraphQL\Login\Auth\ProviderConfig;
 
 use GraphQL\Error\UserError;

--- a/src/Auth/ProviderRegistry.php
+++ b/src/Auth/ProviderRegistry.php
@@ -6,6 +6,8 @@
  * @since 0.0.1
  */
 
+declare( strict_types = 1 );
+
 namespace WPGraphQL\Login\Auth;
 
 use WPGraphQL\Login\Auth\ProviderConfig\OAuth2\Facebook;

--- a/src/Auth/Request.php
+++ b/src/Auth/Request.php
@@ -6,6 +6,8 @@
  * @since 0.0.6
  */
 
+declare( strict_types = 1 );
+
 namespace WPGraphQL\Login\Auth;
 
 use GraphQL\Error\UserError;

--- a/src/Auth/ServerAuthentication.php
+++ b/src/Auth/ServerAuthentication.php
@@ -6,6 +6,8 @@
  * @since @todo
  */
 
+declare( strict_types = 1 );
+
 namespace WPGraphQL\Login\Auth;
 
 use WPGraphQL\Login\Vendor\AxeWP\GraphQL\Interfaces\Registrable;

--- a/src/Auth/TokenManager.php
+++ b/src/Auth/TokenManager.php
@@ -6,6 +6,8 @@
  * @since 0.0.1
  */
 
+declare( strict_types = 1 );
+
 namespace WPGraphQL\Login\Auth;
 
 use WPGraphQL\Login\Utils\Utils;

--- a/src/Auth/User.php
+++ b/src/Auth/User.php
@@ -6,6 +6,8 @@
  * @since 0.0.1
  */
 
+declare( strict_types = 1 );
+
 namespace WPGraphQL\Login\Auth;
 
 use WP_User_Query;

--- a/src/Autoloader.php
+++ b/src/Autoloader.php
@@ -6,6 +6,8 @@
  * @since 0.1.4
  */
 
+declare( strict_types = 1 );
+
 namespace WPGraphQL\Login;
 
 /**

--- a/src/CoreSchemaFilters.php
+++ b/src/CoreSchemaFilters.php
@@ -5,6 +5,8 @@
  * @package WPGraphQL\Login
  */
 
+declare( strict_types = 1 );
+
 namespace WPGraphQL\Login;
 
 use GraphQL\Error\UserError;

--- a/src/Fields/RootQuery.php
+++ b/src/Fields/RootQuery.php
@@ -5,6 +5,8 @@
  * @package WPGraphQL\Login\Fields
  */
 
+declare( strict_types = 1 );
+
 namespace WPGraphQL\Login\Fields;
 
 use WPGraphQL\Login\Auth\Client as AuthClient;

--- a/src/Main.php
+++ b/src/Main.php
@@ -5,6 +5,8 @@
  * @package WPGraphQL\Login
  */
 
+declare( strict_types = 1 );
+
 namespace WPGraphQL\Login;
 
 use WPGraphQL\Login\Admin\Settings;

--- a/src/Model/Client.php
+++ b/src/Model/Client.php
@@ -5,6 +5,8 @@
  * @package WPGraphQL\Login\Model
  */
 
+declare( strict_types = 1 );
+
 namespace WPGraphQL\Login\Model;
 
 use WPGraphQL\Model\Model;

--- a/src/Model/User.php
+++ b/src/Model/User.php
@@ -5,6 +5,8 @@
  * @package WPGraphQL\Login\Model
  */
 
+declare( strict_types = 1 );
+
 namespace WPGraphQL\Login\Model;
 
 use WPGraphQL\Login\Auth\TokenManager;

--- a/src/Mutation/LinkUserIdentity.php
+++ b/src/Mutation/LinkUserIdentity.php
@@ -6,6 +6,8 @@
  * @since 0.0.1
  */
 
+declare( strict_types = 1 );
+
 namespace WPGraphQL\Login\Mutation;
 
 use GraphQL\Type\Definition\ResolveInfo;

--- a/src/Mutation/Login.php
+++ b/src/Mutation/Login.php
@@ -6,6 +6,8 @@
  * @since 0.0.1
  */
 
+declare( strict_types = 1 );
+
 namespace WPGraphQL\Login\Mutation;
 
 use GraphQL\Type\Definition\ResolveInfo;

--- a/src/Mutation/RefreshToken.php
+++ b/src/Mutation/RefreshToken.php
@@ -6,6 +6,8 @@
  * @since 0.0.1
  */
 
+declare( strict_types = 1 );
+
 namespace WPGraphQL\Login\Mutation;
 
 use GraphQL\Type\Definition\ResolveInfo;

--- a/src/Mutation/RefreshUserSecret.php
+++ b/src/Mutation/RefreshUserSecret.php
@@ -6,6 +6,8 @@
  * @since 0.0.1
  */
 
+declare( strict_types = 1 );
+
 namespace WPGraphQL\Login\Mutation;
 
 use GraphQL\Error\UserError;

--- a/src/Mutation/RevokeUserSecret.php
+++ b/src/Mutation/RevokeUserSecret.php
@@ -6,6 +6,8 @@
  * @since 0.0.1
  */
 
+declare( strict_types = 1 );
+
 namespace WPGraphQL\Login\Mutation;
 
 use GraphQL\Error\UserError;

--- a/src/Type/Enum/GoogleProviderPromptTypeEnum.php
+++ b/src/Type/Enum/GoogleProviderPromptTypeEnum.php
@@ -6,6 +6,8 @@
  * @since 0.0.1
  */
 
+declare( strict_types = 1 );
+
 namespace WPGraphQL\Login\Type\Enum;
 
 use WPGraphQL\Login\Vendor\AxeWP\GraphQL\Abstracts\EnumType;

--- a/src/Type/Enum/ProviderEnum.php
+++ b/src/Type/Enum/ProviderEnum.php
@@ -6,6 +6,8 @@
  * @since 0.0.1
  */
 
+declare( strict_types = 1 );
+
 namespace WPGraphQL\Login\Type\Enum;
 
 use WPGraphQL\Login\Auth\ProviderRegistry;

--- a/src/Type/Input/OAuthProviderResponseInput.php
+++ b/src/Type/Input/OAuthProviderResponseInput.php
@@ -5,6 +5,8 @@
  * @package WPGraphQL\Login\Type\Input
  */
 
+declare( strict_types = 1 );
+
 namespace WPGraphQL\Login\Type\Input;
 
 use WPGraphQL\Login\Vendor\AxeWP\GraphQL\Abstracts\InputType;

--- a/src/Type/Input/PasswordProviderResponseInput.php
+++ b/src/Type/Input/PasswordProviderResponseInput.php
@@ -5,6 +5,8 @@
  * @package WPGraphQL\Login\Type\Input
  */
 
+declare( strict_types = 1 );
+
 namespace WPGraphQL\Login\Type\Input;
 
 use WPGraphQL\Login\Vendor\AxeWP\GraphQL\Abstracts\InputType;

--- a/src/Type/WPInterface/ClientOptions.php
+++ b/src/Type/WPInterface/ClientOptions.php
@@ -5,6 +5,8 @@
  * @package WPGraphQL\Login\Type\WPInterface
  */
 
+declare( strict_types = 1 );
+
 namespace WPGraphQL\Login\Type\WPInterface;
 
 use WPGraphQL\Login\Auth\ProviderConfig\ProviderConfig;

--- a/src/Type/WPInterface/LoginOptions.php
+++ b/src/Type/WPInterface/LoginOptions.php
@@ -5,6 +5,8 @@
  * @package WPGraphQL\Login\Type\WPInterface
  */
 
+declare( strict_types = 1 );
+
 namespace WPGraphQL\Login\Type\WPInterface;
 
 use WPGraphQL\Login\Auth\ProviderConfig\ProviderConfig;

--- a/src/Type/WPObject/AuthenticationData.php
+++ b/src/Type/WPObject/AuthenticationData.php
@@ -5,6 +5,8 @@
  * @package WPGraphQL\Login\Type\WPObject
  */
 
+declare( strict_types = 1 );
+
 namespace WPGraphQL\Login\Type\WPObject;
 
 use WPGraphQL\Login\Vendor\AxeWP\GraphQL\Abstracts\ObjectType;

--- a/src/Type/WPObject/Client.php
+++ b/src/Type/WPObject/Client.php
@@ -5,6 +5,8 @@
  * @package WPGraphQL\Login\Type\WPObject
  */
 
+declare( strict_types = 1 );
+
 namespace WPGraphQL\Login\Type\WPObject;
 
 use WPGraphQL\Login\Type\Enum\ProviderEnum;

--- a/src/Type/WPObject/ClientOptions.php
+++ b/src/Type/WPObject/ClientOptions.php
@@ -5,6 +5,8 @@
  * @package WPGraphQL\Login\Type\WPObject
  */
 
+declare( strict_types = 1 );
+
 namespace WPGraphQL\Login\Type\WPObject;
 
 use WPGraphQL\Login\Auth\ProviderRegistry;

--- a/src/Type/WPObject/LinkedIdentity.php
+++ b/src/Type/WPObject/LinkedIdentity.php
@@ -5,6 +5,8 @@
  * @package WPGraphQL\Login\Type\WPObject
  */
 
+declare( strict_types = 1 );
+
 namespace WPGraphQL\Login\Type\WPObject;
 
 use WPGraphQL\Login\Type\Enum\ProviderEnum;

--- a/src/Type/WPObject/LoginOptions.php
+++ b/src/Type/WPObject/LoginOptions.php
@@ -5,6 +5,8 @@
  * @package WPGraphQL\Login\Type\WPObject
  */
 
+declare( strict_types = 1 );
+
 namespace WPGraphQL\Login\Type\WPObject;
 
 use WPGraphQL\Login\Auth\ProviderRegistry;

--- a/src/TypeRegistry.php
+++ b/src/TypeRegistry.php
@@ -5,6 +5,8 @@
  * @package WPGraphQL\Login
  */
 
+declare( strict_types = 1 );
+
 namespace WPGraphQL\Login;
 
 use Exception;

--- a/src/Utils/Utils.php
+++ b/src/Utils/Utils.php
@@ -5,6 +5,8 @@
  * @package WPGraphQL/Login/Utils
  */
 
+declare( strict_types = 1 );
+
 namespace WPGraphQL\Login\Utils;
 
 use WPGraphQL\Login\Admin\Settings\AccessControlSettings;

--- a/src/WoocommerceSchemaFilters.php
+++ b/src/WoocommerceSchemaFilters.php
@@ -5,6 +5,8 @@
  * @package WPGraphQL\Login
  */
 
+declare( strict_types = 1 );
+
 namespace WPGraphQL\Login;
 
 use WPGraphQL\Login\Type\WPObject\AuthenticationData;

--- a/wp-graphql-headless-login.php
+++ b/wp-graphql-headless-login.php
@@ -24,6 +24,8 @@
  * @version 0.2.0
  */
 
+declare( strict_types = 1 );
+
 namespace WPGraphQL\Login;
 
 // Exit if accessed directly.


### PR DESCRIPTION
<!--
Thanks for taking the time to submit a Pull Request.
-->

## What
<!-- In a few words, what does this PR actually change -->

Adds `declare( strict_types = 1 )` to all php file headers, to improve type safety.

## Why
<!-- Why is this PR necessary? Please any existing previous issue(s) or PR(s) and include a short summary here, too -->

## How
<!-- How is your PR addressing the issue at hand? What are the implementation details?  -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

## Additional Info
<!-- Please include any relevant logs, error output, GraphiQL screenshots, etc -->

## Checklist:
<!-- We encourage you to complete this checklist to the best of your abilities. If you can't do everything, that's okay too.  -->
- [x] My code is tested to the best of my abilities.
- [x] My code follows the WordPress Coding Standards. <!-- Check code: `composer run check-cs`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/ -->
- [x] I have added unit tests to verify the code works as intended.
- [x] I included the relevant changes in CHANGELOG.md
