### PR TITLE
chore: update `docker-compose` commands to `docker compose`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to a modified version of [Semantic Versioning](./README
 
 - chore: Update Strauss to v0.19.1.
 - chore: Update Composer dependencies.
+- ci: Replace `docker-compose` commands with `docker compose`.
 
 ## [0.3.0] - 2024-04-06
 

--- a/bin/run-docker.sh
+++ b/bin/run-docker.sh
@@ -4,7 +4,7 @@ set -eu
 
 ##
 # Use this script through Composer scripts in the package.json.
-# To quickly build and run the docker-compose scripts for an app or automated testing
+# To quickly build and run the docker compose scripts for an app or automated testing
 # run the command below after run `composer install --no-dev` with the respectively
 # flag for what you need.
 ##
@@ -83,7 +83,7 @@ case "$subcommand" in
 			WP_VERSION=${WP_VERSION} PHP_VERSION=${PHP_VERSION} docker compose up app
 			;;
 		t)
-			docker-compose run --rm \
+			docker compose run --rm \
 				-e COVERAGE=${COVERAGE-} \
 				-e USING_XDEBUG=${USING_XDEBUG-} \
 				-e DEBUG=${DEBUG-} \

--- a/composer.json
+++ b/composer.json
@@ -110,7 +110,7 @@
 		"docker-build": "bash bin/run-docker.sh build",
 		"delete-vendor-files": "rm -rf composer.lock vendor src/vendor-prefixed/*",
 		"docker-run": "bash bin/run-docker.sh run",
-		"docker-destroy": "docker-compose down",
+		"docker-destroy": "docker compose down",
 		"build-and-run": [
 			"@docker-build",
 			"@docker-run"


### PR DESCRIPTION
<!--
Thanks for taking the time to submit a Pull Request.
-->

## What
<!-- In a few words, what does this PR actually change -->
Replaces calls to `docker-compose` with `docker compose`.

## Why
<!-- Why is this PR necessary? Please any existing previous issue(s) or PR(s) and include a short summary here, too -->

The old commands are no longer included in the GH runner.

## How
<!-- How is your PR addressing the issue at hand? What are the implementation details?  -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

## Additional Info
<!-- Please include any relevant logs, error output, GraphiQL screenshots, etc -->

## Checklist:
<!-- We encourage you to complete this checklist to the best of your abilities. If you can't do everything, that's okay too.  -->
- [x] My code is tested to the best of my abilities.
- [x] My code follows the WordPress Coding Standards. <!-- Check code: `composer run check-cs`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/ -->
- [x] I have added unit tests to verify the code works as intended.
- [x] I included the relevant changes in CHANGELOG.md
