### PR TITLE
fix: use `defaultValue` in field control

### DIFF
--- a/packages/admin/components/fields/field-control.tsx
+++ b/packages/admin/components/fields/field-control.tsx
@@ -77,7 +77,7 @@ export const FieldControl = ( {
 	onChange,
 	required,
 	type,
-	value,
+	value: originalValue,
 	...rest
 }: FieldControlProps ) => {
 	const controlType =
@@ -92,6 +92,9 @@ export const FieldControl = ( {
 	if ( ! ControlComponent ) {
 		return null;
 	}
+
+	// Fallback to the default value if the value is not set.
+	const value = originalValue ?? rest?.default;
 
 	// Build the component props.
 	let componentProps: ControlComponentPropsMap[ typeof controlType ] = {


### PR DESCRIPTION
<!--
Thanks for taking the time to submit a Pull Request.
-->

## What
<!-- In a few words, what does this PR actually change -->

This PR updates the Field Control components to use the `defaultValue` if no field value is explicitly set.

## Why
<!-- Why is this PR necessary? Please any existing previous issue(s) or PR(s) and include a short summary here, too -->

Backported from #129 . Props @alexookah

## How
<!-- How is your PR addressing the issue at hand? What are the implementation details?  -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

## Additional Info
<!-- Please include any relevant logs, error output, GraphiQL screenshots, etc -->

## Checklist:
<!-- We encourage you to complete this checklist to the best of your abilities. If you can't do everything, that's okay too.  -->
- [ ] My code is tested to the best of my abilities.
- [ ] My code follows the WordPress Coding Standards. <!-- Check code: `composer run check-cs`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/ -->
- [ ] I have added unit tests to verify the code works as intended.
- [ ] I included the relevant changes in CHANGELOG.md
