### PR TITLE
dev: source setting screens from global

### DIFF
--- a/packages/admin/components/fields/index.tsx
+++ b/packages/admin/components/fields/index.tsx
@@ -1,4 +1,4 @@
-import type { AllowedSettingKeys, SettingSchema } from '@/admin/types';
+import type { FieldSchema } from '@/admin/types';
 import { Field } from './field';
 
 export const Fields = ( {
@@ -9,7 +9,7 @@ export const Fields = ( {
 }: {
 	excludedProperties?: string[];
 	values: Record< string, unknown > | undefined;
-	fields: SettingSchema[ AllowedSettingKeys ];
+	fields: Record< string, FieldSchema >;
 	setValue: ( values: Record< string, unknown > ) => void;
 } ) => {
 	if ( ! values ) {

--- a/packages/admin/components/layout/header/menu/index.tsx
+++ b/packages/admin/components/layout/header/menu/index.tsx
@@ -2,7 +2,7 @@ import { Button, Icon, NavigableMenu } from '@wordpress/components';
 import { link as LinkSVG } from '@wordpress/icons';
 import { __ } from '@wordpress/i18n';
 import { useCurrentScreen } from '@/admin/components/screen/context';
-import type { AllowedScreens } from '@/admin/components/screen/screen';
+import { getScreenForSetting } from '@/admin/components/screen/utils';
 
 import styles from './styles.module.scss';
 
@@ -13,43 +13,57 @@ const LinkIcon = () => {
 	return <Icon icon={ LinkSVG } className={ styles.linkIcon } size={ 16 } />;
 };
 
-const SCREEN_LABELS: Record< AllowedScreens, string > = {
-	providers: __( 'Login Providers', 'wp-graphql-headless-login' ),
-	'access-control': __( 'Access Control', 'wp-graphql-headless-login' ),
-	'plugin-settings': __( 'Misc', 'wp-graphql-headless-login' ),
+/**
+ * Builds and returns the menu object from the wpGraphQLLogin.settings global.
+ */
+export const getMenuObject = (): Record< string, string > => {
+	const settings = wpGraphQLLogin.settings;
+
+	const menu: Record< string, string > = {
+		providers: '', // We want this as the first key.
+	};
+
+	for ( const key in settings ) {
+		// @todo get providers from global after the refactor.
+		const menuTitle =
+			settings[ key ].label ||
+			__( 'Providers', 'wp-graphql-headless-login' );
+		const screen = getScreenForSetting( key );
+
+		menu[ screen ] = menuTitle;
+	}
+
+	return menu;
 };
 
 export const Menu = () => {
 	const { currentScreen, setCurrentScreen } = useCurrentScreen();
+
+	// Build the menu object of screens and labels from the wpGraphQLLogin?.settings.
+	const menuItems = getMenuObject();
 
 	return (
 		<NavigableMenu orientation="horizontal">
 			<ul role="menubar" className={ styles.menu }>
 				{
 					// Loop through the screen titles and create a button for each one.
-					Object.entries( SCREEN_LABELS ).map(
-						( [ screen, title ] ) => (
-							<li key={ screen }>
-								<Button
-									key={ screen }
-									className={
-										currentScreen === screen
-											? styles.active
-											: ''
-									}
-									variant="tertiary"
-									onClick={ () =>
-										setCurrentScreen(
-											screen as AllowedScreens
-										)
-									}
-									role="menuitem"
-								>
-									{ title }
-								</Button>
-							</li>
-						)
-					)
+					Object.entries( menuItems ).map( ( [ screen, title ] ) => (
+						<li key={ screen }>
+							<Button
+								key={ screen }
+								className={
+									currentScreen === screen
+										? styles.active
+										: ''
+								}
+								variant="tertiary"
+								onClick={ () => setCurrentScreen( screen ) }
+								role="menuitem"
+							>
+								{ title }
+							</Button>
+						</li>
+					) )
 				}
 				<li>
 					<Button

--- a/packages/admin/components/screen/context.tsx
+++ b/packages/admin/components/screen/context.tsx
@@ -6,11 +6,11 @@ import {
 	useContext,
 	startTransition,
 } from 'react';
-import { SCREEN_MAP, type AllowedScreens } from './screen';
+import { isAllowedScreen } from './utils';
 
 const ScreenContext = createContext< {
-	currentScreen: AllowedScreens;
-	setCurrentScreen: ( screen: AllowedScreens ) => void;
+	currentScreen: string;
+	setCurrentScreen: ( screen: string ) => void;
 } >( {
 	currentScreen: 'providers',
 	setCurrentScreen: () => {}, // eslint-disable-line @typescript-eslint/no-empty-function
@@ -18,7 +18,7 @@ const ScreenContext = createContext< {
 
 export const ScreenProvider = ( { children }: PropsWithChildren ) => {
 	const [ currentScreen, setCurrentScreen ] =
-		useState< AllowedScreens >( 'providers' );
+		useState< string >( 'providers' );
 
 	// The screen is set as a query parameter in the URL.
 	useEffect( () => {
@@ -26,8 +26,9 @@ export const ScreenProvider = ( { children }: PropsWithChildren ) => {
 			const url = new URL( window.location.href );
 			const screen = url.searchParams.get( 'screen' );
 
-			if ( screen && screen in SCREEN_MAP ) {
-				setCurrentScreen( screen as AllowedScreens );
+			// Allowed screens appear in the WPGraphQLLogin.settings global.
+			if ( screen && isAllowedScreen( screen ) ) {
+				setCurrentScreen( screen );
 			}
 		} );
 	}, [] );

--- a/packages/admin/components/screen/screen.tsx
+++ b/packages/admin/components/screen/screen.tsx
@@ -1,59 +1,23 @@
-import { __ } from '@wordpress/i18n';
 import { Panel, PanelBody, PanelRow } from '@wordpress/components';
 import clsx from 'clsx';
 import { lazy, Suspense, type PropsWithChildren } from 'react';
 import { Loading } from '@/admin/components/ui/loading';
 import { useCurrentScreen } from './context';
 import { SettingsScreen } from './setting-screen';
-import type { AllowedSettingKeys } from '@/admin/types';
 
 import styles from './styles.module.scss';
+import { getSettingForScreen } from './utils';
+import { __ } from '@wordpress/i18n';
 
 const ClientSettingsScreen = lazy(
 	() => import( '../provider-config/ClientSettings' )
 );
-
-export type AllowedScreens = 'access-control' | 'providers' | 'plugin-settings';
-
-export const SCREEN_MAP: Record< AllowedScreens, AllowedSettingKeys > = {
-	'access-control': 'wpgraphql_login_access_control',
-	'plugin-settings': 'wpgraphql_login_settings',
-	providers: 'providers',
-};
 
 /**
  * The titles of the screens that are available in the admin.
  *
  * @todo get from the server.
  */
-const SCREEN_TITLES: Record< AllowedScreens, string > = {
-	'access-control': __(
-		'Access Control Settings',
-		'wp-graphql-headless-login'
-	),
-	'plugin-settings': __( 'Plugin Settings', 'wp-graphql-headless-login' ),
-	providers: __( 'Login Providers', 'wp-graphql-headless-login' ),
-};
-
-/**
- * The descriptions of the screens that are available in the admin.
- *
- * @todo get from the server.
- */
-const SCREEN_DESCRIPTIONS: Record< AllowedScreens, string > = {
-	'access-control': __(
-		'Configure the Access Control headers for the plugin.',
-		'wp-graphql-headless-login'
-	),
-	'plugin-settings': __(
-		'Configure the plugin settings.',
-		'wp-graphql-headless-login'
-	),
-	providers: __(
-		'Configure the Authentication Providers that are available to users.',
-		'wp-graphql-headless-login'
-	),
-};
 
 const Wrapper = ( {
 	title,
@@ -85,8 +49,18 @@ const Wrapper = ( {
 export const Screen = () => {
 	const { currentScreen } = useCurrentScreen();
 
-	const title = SCREEN_TITLES[ currentScreen ];
-	const description = SCREEN_DESCRIPTIONS[ currentScreen ];
+	const settingKey = getSettingForScreen( currentScreen );
+
+	// @todo get provider context from global.
+	const title =
+		wpGraphQLLogin?.settings[ settingKey ]?.title ||
+		__( 'Login Providers', 'wp-graphql-headless-login' );
+	const description =
+		wpGraphQLLogin?.settings[ settingKey ]?.description ||
+		__(
+			'Configure the Authentication Providers that are available to users.',
+			'wp-graphql-headless-login'
+		);
 
 	return (
 		<Suspense fallback={ <Loading /> }>
@@ -94,9 +68,7 @@ export const Screen = () => {
 				{ currentScreen === 'providers' ? (
 					<ClientSettingsScreen />
 				) : (
-					<SettingsScreen
-						settingKey={ SCREEN_MAP[ currentScreen ] }
-					/>
+					<SettingsScreen settingKey={ settingKey } />
 				) }
 			</Wrapper>
 		</Suspense>

--- a/packages/admin/components/screen/setting-screen.tsx
+++ b/packages/admin/components/screen/setting-screen.tsx
@@ -4,13 +4,8 @@ import { useEffect } from 'react';
 import { Button, PanelBody, Spinner } from '@wordpress/components';
 import { Fields } from '@/admin/components/fields';
 import { useSettings } from '@/admin/contexts/settings-context';
-import type { AllowedSettingKeys } from '@/admin/types';
 
-export const SettingsScreen = ( {
-	settingKey,
-}: {
-	settingKey: AllowedSettingKeys;
-} ) => {
+export const SettingsScreen = ( { settingKey }: { settingKey: string } ) => {
 	const {
 		settings: allSettings,
 		updateSettings,
@@ -19,7 +14,8 @@ export const SettingsScreen = ( {
 		errorMessage,
 	} = useSettings();
 
-	const optionsSchema = wpGraphQLLogin?.settings?.[ settingKey ] || undefined;
+	const optionsSchema =
+		wpGraphQLLogin?.settings?.[ settingKey ]?.fields || undefined;
 
 	const settings = allSettings?.[ settingKey ] || undefined;
 

--- a/packages/admin/components/screen/utils.ts
+++ b/packages/admin/components/screen/utils.ts
@@ -1,0 +1,47 @@
+/**
+ * Maps a plugin setting key to to its corresponding screen.
+ *
+ * @param {string} setting The setting to map to a screen. E.g. `wpgraphql_login_access_control`.
+ */
+export const getScreenForSetting = ( setting: string ): string => {
+	const settingPrefix = 'wpgraphql_login_';
+
+	// First, strip the prefix.
+	const settingWithoutPrefix = setting.replace( settingPrefix, '' );
+
+	// Then, convert to `kebab-case`.
+	return settingWithoutPrefix.replace( /_/g, '-' );
+};
+
+/**
+ * Maps a screen to it's corresponding plugin setting.
+ *
+ * @param {string} screen The screen to map to a setting. E.g. `access-control`.
+ */
+export const getSettingForScreen = ( screen: string ): string => {
+	const settingPrefix = 'wpgraphql_login_';
+
+	// First, convert to `snake_case`.
+	const snakeCaseScreen = screen.replace( /-/g, '_' );
+
+	// Then, add the prefix.
+	const setting = settingPrefix + snakeCaseScreen;
+
+	// Ensure lowercase
+	return setting.toLowerCase();
+};
+
+/**
+ * Checks whether a screen is allowed.
+ *
+ * Allowed screens are the keys defined in the `WPGraphQLLogin.settings` global.
+ *
+ * @param {string} screen The screen to check.
+ */
+export const isAllowedScreen = ( screen: string ): boolean => {
+	const allowedSettings = Object.keys( wpGraphQLLogin.settings );
+
+	const settingToCheck = getSettingForScreen( screen );
+
+	return allowedSettings.includes( settingToCheck );
+};

--- a/packages/admin/contexts/settings-context.tsx
+++ b/packages/admin/contexts/settings-context.tsx
@@ -6,13 +6,12 @@ import {
 	useState,
 } from 'react';
 import apiFetch from '@wordpress/api-fetch';
-import type { AllowedSettingKeys } from '@/admin/types';
 
 const REST_ENDPOINT = 'wp-graphql-login/v1/settings';
 
 type AllowedStatuses = 'saving' | 'complete' | undefined;
 
-type SettingType = Record< AllowedSettingKeys, Record< string, unknown > >;
+type SettingType = Record< string, Record< string, unknown > >;
 
 const SettingsContext = createContext< {
 	settings: SettingType | undefined;

--- a/packages/admin/types.d.ts
+++ b/packages/admin/types.d.ts
@@ -16,11 +16,6 @@ declare global {
 	};
 }
 
-type AllowedSettingKeys =
-	| 'providers'
-	| 'wpgraphql_login_settings'
-	| 'wpgraphql_login_access_control';
-
 type AllowedConditionalLogicOperators = '==' | '!=' | '>' | '<' | '>=' | '<=';
 
 type FieldSchema = {
@@ -45,10 +40,14 @@ type FieldSchema = {
 	required?: boolean;
 };
 
-type SettingSchema = Record<
-	AllowedSettingKeys,
-	Record< string, FieldSchema >
->;
+type SettingSchema = {
+	[ key: string ]: {
+		title: string;
+		description: string;
+		label: string;
+		fields: Record< string, FieldSchema >;
+	}
+};
 
 type ProviderSettingType = {
 	name: string;

--- a/src/Admin/Settings/AbstractSettings.php
+++ b/src/Admin/Settings/AbstractSettings.php
@@ -58,6 +58,11 @@ abstract class AbstractSettings {
 	abstract public function get_title(): string;
 
 	/**
+	 * The label used in the menu
+	 */
+	abstract public function get_label(): string;
+
+	/**
 	 * The screen description.
 	 */
 	abstract public function get_description(): string;
@@ -120,7 +125,7 @@ abstract class AbstractSettings {
 	/**
 	 * Get the config used to render the settings in the UI.
 	 *
-	 * @return array<string,array{
+	 * @return array{title:string,description:string,fields:array<string,array{
 	 *  description: string,
 	 *  label: string,
 	 *  type: string,
@@ -135,13 +140,13 @@ abstract class AbstractSettings {
 	 *  help?: string,
 	 *  isAdvanced?: bool,
 	 *  required?: bool,
-	 * }>
+	 * }>}
 	 */
 	public function get_render_config(): array {
 		$config = $this->get_config();
 
 		// Unset the excluded keys.
-		return array_map(
+		$fields = array_map(
 			static function ( $setting ) {
 				$excluded_keys = [
 					'sanitize_callback',
@@ -156,6 +161,13 @@ abstract class AbstractSettings {
 			},
 			$config
 		);
+
+		return [
+			'title'       => $this->get_title(),
+			'label'       => $this->get_label(),
+			'description' => $this->get_description(),
+			'fields'      => $fields,
+		];
 	}
 
 	/**

--- a/src/Admin/Settings/AccessControlSettings.php
+++ b/src/Admin/Settings/AccessControlSettings.php
@@ -31,6 +31,13 @@ class AccessControlSettings extends AbstractSettings {
 	/**
 	 * {@inheritDoc}
 	 */
+	public function get_label(): string {
+		return __( 'Access Control', 'wp-graphql-headless-login' );
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
 	public function get_description(): string {
 		return __( 'Manage Access Control settings for the plugin.', 'wp-graphql-headless-login' );
 	}

--- a/src/Admin/Settings/PluginSettings.php
+++ b/src/Admin/Settings/PluginSettings.php
@@ -31,6 +31,13 @@ class PluginSettings extends AbstractSettings {
 	/**
 	 * {@inheritDoc}
 	 */
+	public function get_label(): string {
+		return __( 'Misc', 'wp-graphql-headless-login' );
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
 	public function get_description(): string {
 		return __( 'Miscellaneous settings for the plugin.', 'wp-graphql-headless-login' );
 	}


### PR DESCRIPTION
<!--
Thanks for taking the time to submit a Pull Request.
-->

## What
<!-- In a few words, what does this PR actually change -->

This PR refactors the frontend package to source the screen titles, menu label, and descriptions from the server via the `wpGraphQLLogin.settings` global.

## Why
<!-- Why is this PR necessary? Please any existing previous issue(s) or PR(s) and include a short summary here, too -->

So new settings don't need to be manually allow-listed.

## How
<!-- How is your PR addressing the issue at hand? What are the implementation details?  -->

Provider screen is still manually hydrated until that component gets refactored.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

## Additional Info
<!-- Please include any relevant logs, error output, GraphiQL screenshots, etc -->

## Checklist:
<!-- We encourage you to complete this checklist to the best of your abilities. If you can't do everything, that's okay too.  -->
- [x] My code is tested to the best of my abilities.
- [x] My code follows the WordPress Coding Standards. <!-- Check code: `composer run check-cs`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/ -->
- [x] I have added unit tests to verify the code works as intended.
- [x] I included the relevant changes in CHANGELOG.md
