### PR TITLE
Fix provider settings admin regression on WordPress 7.1

### DIFF
--- a/packages/admin/components/provider-config/ClientMenu.tsx
+++ b/packages/admin/components/provider-config/ClientMenu.tsx
@@ -1,11 +1,7 @@
-/* eslint-disable @wordpress/no-unsafe-wp-apis */
-import {
-	__experimentalNavigation as Navigation,
-	__experimentalNavigationItem as NavigationItem,
-	__experimentalNavigationMenu as NavigationMenu,
-} from '@wordpress/components';
+import { Button, Flex, FlexItem } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useEntityProp } from '@wordpress/core-data';
+
 import { useClientContext } from '@/admin/contexts/provider-config-context';
 
 import styles from './styles.module.scss';
@@ -25,36 +21,46 @@ export function StatusBadge( { provider }: { provider: string } ) {
 				className={ isEnabled ? styles?.[ 'enabled' ] : undefined }
 				aria-label={ title }
 				title={ title }
-			></span>
+			/>
 		</div>
 	);
 }
 
 export function ClientMenu() {
 	const providers = Object.keys( wpGraphQLLogin?.settings?.providers || {} );
+
 	const { activeClient, setActiveClient } = useClientContext();
 
 	return (
-		<Navigation activeItem={ activeClient }>
-			<NavigationMenu
-				title={ __( 'Providers', 'wp-graphql-headless-login' ) }
-			>
-				{ providers.length > 0 &&
-					providers.map( ( provider ) => (
-						<NavigationItem
-							className={ styles?.[ 'menuItem' ] ?? '' }
-							key={ provider }
-							item={ provider }
-							title={
-								wpGraphQLLogin?.settings?.providers?.[
-									provider
-								]?.[ 'name' ]?.default as string
-							}
-							icon={ <StatusBadge provider={ provider } /> }
-							onClick={ () => setActiveClient( provider ) }
-						/>
-					) ) }
-			</NavigationMenu>
-		</Navigation>
+		<Flex direction="column" gap={ 1 }>
+			<FlexItem>
+				<strong>
+					{ __( 'Providers', 'wp-graphql-headless-login' ) }
+				</strong>
+			</FlexItem>
+
+			{ providers.map( ( provider ) => (
+				<FlexItem key={ provider }>
+					<Button
+						className={ styles?.[ 'menuItem' ] ?? '' }
+						variant={
+							activeClient === provider ? 'secondary' : 'tertiary'
+						}
+						onClick={ () => setActiveClient( provider ) }
+						aria-current={
+							activeClient === provider ? 'page' : undefined
+						}
+					>
+						<StatusBadge provider={ provider } />
+
+						{
+							wpGraphQLLogin?.settings?.providers?.[ provider ]?.[
+								'name'
+							]?.default as string
+						}
+					</Button>
+				</FlexItem>
+			) ) }
+		</Flex>
 	);
 }

--- a/packages/admin/components/provider-config/ClientPanel.tsx
+++ b/packages/admin/components/provider-config/ClientPanel.tsx
@@ -6,6 +6,7 @@ import {
 	PanelRow,
 	Placeholder,
 	Spinner,
+	ToggleControl,
 } from '@wordpress/components';
 import { sprintf, __ } from '@wordpress/i18n';
 import { store as coreStore } from '@wordpress/core-data';
@@ -163,6 +164,7 @@ export function ClientPanel() {
 				</PanelRow>
 				<Fields
 					excludedProperties={ [
+						'isEnabled',
 						'loginOptions',
 						'clientOptions',
 						'order',
@@ -179,6 +181,18 @@ export function ClientPanel() {
 						} );
 					} }
 				/>
+				<PanelRow>
+					<ToggleControl
+						label={ __(
+							'Enable Provider',
+							'wp-graphql-headless-login'
+						) }
+						checked={ !! clientConfig.isEnabled }
+						onChange={ ( isEnabled ) => {
+							updateClient( 'isEnabled', isEnabled );
+						} }
+					/>
+				</PanelRow>
 				<ClientOptionList
 					clientSlug={ activeClient }
 					optionsKey="clientOptions"

--- a/packages/admin/contexts/provider-config-context.tsx
+++ b/packages/admin/contexts/provider-config-context.tsx
@@ -123,7 +123,7 @@ export const ProviderConfigProvider = ( { children }: PropsWithChildren ) => {
 		) {
 			setClientConfig( {
 				...clientDefaults,
-				slug: activeClient,
+				slug: activeClient.replace( PROVIDER_PREFIX, '' ),
 			} );
 		}
 	}, [ clientConfig, setClientConfig, activeClient ] );


### PR DESCRIPTION
## What this fixes

After a WordPress core update, the Headless Login provider settings screen started throwing React error #130 because it relied on experimental Navigation components that are no longer available in the affected WordPress environment.

This PR:

* Replaces the unavailable experimental Navigation components in `ClientMenu`.
* Preserves the existing provider selection and `ProviderConfigProvider` state flow.
* Restores the **Enable Provider** toggle explicitly in `ClientPanel`.
* Excludes `isEnabled` from the generic `Fields` rendering to prevent duplicate controls.
* Fixes provider slug normalization when initializing provider configuration, preventing prefixed provider keys such as `wpgraphql_login_provider_facebook` from being submitted as the REST `slug`.
* Leaves provider options, login options, saving, and custom provider panels unchanged.

## Debugging

The `/wp-json/wp/v2/settings` endpoint was confirmed to return the provider configuration correctly, including `isEnabled` values.

The affected environment exposed the current `Navigator` API but not the old `__experimentalNavigation`, `__experimentalNavigationItem`, and `__experimentalNavigationMenu` exports.

The resulting error was:

`Minified React error #130`

The Enable/Disable Provider control was also missing after replacing the navigation UI and was restored by explicitly rendering the existing `isEnabled` setting as a `ToggleControl`.

A separate multisite regression was identified during testing where provider initialization could set:

`slug: wpgraphql_login_provider_facebook`

instead of the REST schema's expected:

`slug: facebook`

The provider prefix is now removed when creating the initial provider configuration.

## Testing

Tested against the affected WordPress environment and two multisite installations.

Verified:

* Admin provider settings load without React error #130.
* Providers can be selected.
* Enable/Disable Provider toggle is displayed.
* Provider controls remain available.
* Provider settings can be saved.
* Provider slug validation succeeds on multisite.
* Facebook and LinkedIn provider settings save successfully after the slug normalization fix.

I have **not tested this change against older WordPress versions**.
